### PR TITLE
140 issue with rotating file sink logger

### DIFF
--- a/ChronoAPI/ChronoLog/include/log.h
+++ b/ChronoAPI/ChronoLog/include/log.h
@@ -80,13 +80,14 @@ public:
      * @param loggerName   The name of the logger, used in formatted output.
      * @param logFileSize  Maximum size of log file before rotating (in Bytes).
      * @param logFileNum   Number of log files to maintain before overwriting.
+     * @param flushLevel   The logging level for the logger to flush into file when file logging mode.
      *
      * @return             Returns 0 if the logger was initialized successfully,
      *                     and returns 1 if there was an error during initialization.
      */
     static int initialize(const std::string &logType, const std::string &location, spdlog::level::level_enum logLevel
-                          , const std::string &loggerName, const std::size_t &logFileSize
-                          , const std::size_t &logFileNum);
+                          , const std::string &loggerName, const std::size_t &logFileSize, const std::size_t &logFileNum
+                          , spdlog::level::level_enum flushLevel);
 
 
     /**

--- a/ChronoAPI/ChronoLog/src/log.cpp
+++ b/ChronoAPI/ChronoLog/src/log.cpp
@@ -12,7 +12,8 @@ std::shared_ptr <spdlog::logger> Logger::logger = nullptr;
 std::mutex Logger::mutex;
 
 int Logger::initialize(const std::string &logType, const std::string &location, spdlog::level::level_enum logLevel
-                       , const std::string &loggerName, const std::size_t &logFileSize, const std::size_t &logFileNum)
+                       , const std::string &loggerName, const std::size_t &logFileSize, const std::size_t &logFileNum
+                       , spdlog::level::level_enum flushLevel)
 {
     std::lock_guard <std::mutex> lock(mutex);
     if(logger)
@@ -42,6 +43,7 @@ int Logger::initialize(const std::string &logType, const std::string &location, 
             return 1;
         }
         logger = std::make_shared <spdlog::logger>(loggerName, sink);
+        logger->flush_on(flushLevel);
         logger->set_level(logLevel);
     }
     catch(const spdlog::spdlog_ex &ex)

--- a/ChronoKeeper/ChronoKeeperInstance.cpp
+++ b/ChronoKeeper/ChronoKeeperInstance.cpp
@@ -77,7 +77,8 @@ int main(int argc, char**argv)
                                     , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGLEVEL
                                     , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGNAME
                                     , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILESIZE
-                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILENUM);
+                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.LOGFILENUM
+                                    , confManager.KEEPER_CONF.KEEPER_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_dtype_test.cpp
@@ -487,7 +487,7 @@ int main(int argc, char*argv[])
     uint64_t client_id = CLIENT_ID;
 
     int result = Logger::initialize("console", "cmp_vlen_bytes_dtype_test.log", spdlog::level::debug
-                                    , "cmp_vlen_bytes_dtype_test", 102400, 1);
+                                    , "cmp_vlen_bytes_dtype_test", 102400, 1, spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
+++ b/ChronoStore/test/cmp_vlen_bytes_vs_blob_map.cpp
@@ -1161,7 +1161,7 @@ int readStoryChunkInJSON(StoryChunk &story_chunk)
 int main(int argc, char*argv[])
 {
     int result = Logger::initialize("console", "cmp_vlen_bytes_vs_blob_map.log", spdlog::level::debug
-                                    , "cmp_vlen_bytes_vs_blob_map", 102400, 1);
+                                    , "cmp_vlen_bytes_vs_blob_map", 102400, 1, spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
+++ b/ChronoStore/test/cmp_vlen_str_dtype_test.cpp
@@ -213,7 +213,8 @@ int main(int argc, char*argv[])
     uint64_t story_id = STORY_ID; //dist(rng);
     uint64_t client_id = CLIENT_ID;
 
-    int result = Logger::initialize("console", "cmp_vlen_str_dtype_test.log", spdlog::level::debug, "cmp_vlen_str_dtype_test", 102400, 1);
+    int result = Logger::initialize("console", "cmp_vlen_str_dtype_test.log", spdlog::level::debug
+                                    , "cmp_vlen_str_dtype_test", 102400, 1, spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoStore/test/hdf5_archiver_test.cpp
+++ b/ChronoStore/test/hdf5_archiver_test.cpp
@@ -153,7 +153,7 @@ int main(int argc, char*argv[])
     uint64_t client_id = CLIENT_ID;
 
     int result = Logger::initialize("console", "hdf5_archiver_test.log", spdlog::level::debug, "hdf5_archiver_test"
-                                    , 102400, 1);
+                                    , 102400, 1, spdlog::level::debug);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/ChronoVisor/src/chronovisor_instance.cpp
+++ b/ChronoVisor/src/chronovisor_instance.cpp
@@ -45,7 +45,8 @@ int main(int argc, char**argv)
                                     , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGLEVEL
                                     , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGNAME
                                     , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILESIZE
-                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM);
+                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.LOGFILENUM
+                                    , confManager.VISOR_CONF.VISOR_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -298,7 +298,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/chrono_common/ConfigurationManager.h
+++ b/chrono_common/ConfigurationManager.h
@@ -462,7 +462,7 @@ private:
             {
                 std::cout << "[ConfigurationManager] Unknown flush level: " << conf_str << "Set it to default value: "
                                                                                            "Warning" << std::endl;
-                flush_level = flush_level = spdlog::level::warn;
+                flush_level = spdlog::level::warn;
             }
         }
         else

--- a/default_conf.json.in
+++ b/default_conf.json.in
@@ -34,7 +34,8 @@
         "level": "debug",
         "name": "ChronoVisor",
         "filesize": 102400,
-        "filenum": 3
+        "filenum": 3,
+        "flushlevel": ""
       }
     },
     "delayed_data_admin_exit_in_secs": 3
@@ -74,7 +75,8 @@
         "level": "debug",
         "name": "ChronoKeeper",
         "filesize": 102400,
-        "filenum": 3
+        "filenum": 3,
+        "flushlevel": ""
       }
     },
     "story_files_dir": "/tmp/"
@@ -96,7 +98,8 @@
         "level": "debug",
         "name": "ChronoClient",
         "filesize": 102400,
-        "filenum": 3
+        "filenum": 3,
+        "flushlevel": ""
       }
     }
   }

--- a/default_conf.json.in
+++ b/default_conf.json.in
@@ -35,7 +35,7 @@
         "name": "ChronoVisor",
         "filesize": 102400,
         "filenum": 3,
-        "flushlevel": ""
+        "flushlevel": "warning"
       }
     },
     "delayed_data_admin_exit_in_secs": 3
@@ -76,7 +76,7 @@
         "name": "ChronoKeeper",
         "filesize": 102400,
         "filenum": 3,
-        "flushlevel": ""
+        "flushlevel": "warning"
       }
     },
     "story_files_dir": "/tmp/"
@@ -99,7 +99,7 @@
         "name": "ChronoClient",
         "filesize": 102400,
         "filenum": 3,
-        "flushlevel": ""
+        "flushlevel": "warning"
       }
     }
   }

--- a/test/integration/Client/client_lib_connect_rpc_test.cpp
+++ b/test/integration/Client/client_lib_connect_rpc_test.cpp
@@ -28,7 +28,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Client/client_lib_hybrid_argobots_test.cpp
+++ b/test/integration/Client/client_lib_hybrid_argobots_test.cpp
@@ -64,7 +64,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Client/client_lib_metadata_rpc_test.cpp
+++ b/test/integration/Client/client_lib_metadata_rpc_test.cpp
@@ -29,7 +29,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Client/client_lib_multi_argobots_test.cpp
+++ b/test/integration/Client/client_lib_multi_argobots_test.cpp
@@ -99,7 +99,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Client/client_lib_multi_openmp_test.cpp
+++ b/test/integration/Client/client_lib_multi_openmp_test.cpp
@@ -22,7 +22,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Client/client_lib_multi_pthread_test.cpp
+++ b/test/integration/Client/client_lib_multi_pthread_test.cpp
@@ -101,7 +101,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);

--- a/test/integration/Client/client_lib_multi_storytellers.cpp
+++ b/test/integration/Client/client_lib_multi_storytellers.cpp
@@ -117,7 +117,8 @@ int main(int argc, char**argv)
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGLEVEL
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGNAME
                                     , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILESIZE
-                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM);
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.LOGFILENUM
+                                    , confManager.CLIENT_CONF.CLIENT_LOG_CONF.FLUSHLEVEL);
     if(result == 1)
     {
         exit(EXIT_FAILURE);


### PR DESCRIPTION
This pull request addresses Issue #140 related to the rotating file sink logger. Previously, logs were not flushed until program termination, leading to potential loss of logs if the program received a SIGKILL signal.

Key Changes:
- Introduced a default behavior that automatically flushes logs at every warning level message.
- Added the ability to customize this flushing behavior through the configuration file.

All logger usages have been updated to support these improvements, ensuring more reliable logging.