### PR TITLE
 125 story merging logic

### DIFF
--- a/chrono_common/StoryChunk.cpp
+++ b/chrono_common/StoryChunk.cpp
@@ -11,13 +11,19 @@ chl::StoryChunk::StoryChunk(chl::StoryId const &story_id , uint64_t start_time ,
             : storyId(story_id)
             , startTime(start_time)
             , endTime(end_time)
-            , revisionTime(start_time)
-    {
-    }
+            , revisionTime(end_time)
+{
+
+}
+
+/////
 
 chl::StoryChunk::~StoryChunk()
-    {
-    }
+{
+    logEvents.clear();
+}
+
+//////
 
 int chl::StoryChunk::insertEvent(chl::LogEvent const &event)
     {
@@ -30,67 +36,173 @@ int chl::StoryChunk::insertEvent(chl::LogEvent const &event)
         { return 0; }
     }
 
-///////////
+// 
+//  merge into this master chunk all the events from the events map startign at iterator position merge_start
+//  return the merged even count
 
-uint32_t chl::StoryChunk::mergeEvents(std::map <chl::EventSequence, chl::LogEvent> &events
-                                            , std::map <chl::EventSequence, chl::LogEvent>::iterator &merge_start)
+uint32_t chl::StoryChunk::mergeEvents(std::map<chl::EventSequence, chl::LogEvent> & events,
+                                    std::map<chl::EventSequence, chl::LogEvent>::const_iterator & merge_start)
 {
+    LOG_TRACE("[StoryChunk] merge StoryId{} master chunk {}-{} : merging map eventCount {}", 
+                storyId, startTime, endTime, events.size());
+
     uint32_t merged_event_count = 0;
-    std::map <chl::EventSequence, chl::LogEvent>::iterator first_merged, last_merged;
+    std::map<chl::EventSequence, chl::LogEvent>::const_iterator first_merged, last_merged;
+
+    if( events.empty()) 
+    {  return merged_event_count; }
+
 
     if((*merge_start).second.time() < startTime)
     {
         merge_start = events.lower_bound(chl::EventSequence{startTime, 0, 0});
-        LOG_DEBUG("[StoryChunk] Adjusted merge start time to align with StoryChunk's start time: {}", startTime);
+        LOG_DEBUG("[StoryChunk] merge StoryId{} master chunk {} : Adjusted merge_start to align with master chunk startTime", 
+                            storyId, startTime);
     }
 
-    for(auto iter = merge_start; iter != events.end(); ++iter)
+    for(auto iter = merge_start; (iter != events.end()) && ((*iter).second.time() < endTime); ++iter)
     {
+        LOG_TRACE("[StoryChunk] merge StoryId{} master chunk {} : merging event {}, master endTime{}", storyId,
+                  startTime, (*iter).second.time(), endTime);
         if(insertEvent((*iter).second) > 0)
         {
-            if(merged_event_count == 0)
+            if(merged_event_count == 0) 
             { first_merged = iter; }
             last_merged = iter;
             merged_event_count++;
         }
         else
         {
-            LOG_DEBUG("[StoryChunk] Stopped merging due to a record that couldn't be inserted.");
+            //stop at the first record that can't be merged
+            LOG_TRACE("[StoryChunk] merge StoryId {} master chunk {} : stopped merging due to event that couldn't be "
+                      "inserted.{}",
+                      storyId, startTime, (*iter).second.time());
             break;
-        }  //stop at the first record that can't be merged
+        }
     }
 
     if(merged_event_count > 0)
     {
         //remove the merged records from the original map
-        events.erase(first_merged, last_merged);
-        LOG_DEBUG("[StoryChunk] Removed {} merged records from the original event map.", merged_event_count);
+        // removing records in range [first_merged, last_merged]
+        events.erase(first_merged, ++last_merged);
+        LOG_TRACE("[StoryChunk] merge StoryId {} master chunk {} : merged {} records , remaining map eventCount {}",
+                  storyId, startTime, merged_event_count, events.size());
     }
     else
     {
-        LOG_DEBUG("[StoryChunk] No events merged during the operation.");
+        LOG_TRACE("[StoryChunk] merge StoryId {} master chunk {} : No events merged during the operation.", storyId,
+                  startTime);
     }
 
     return merged_event_count;
 }
 
-uint32_t chl::StoryChunk::mergeEvents(chl::StoryChunk &other_chunk, uint64_t start_time, uint64_t end_time)
-    { return 0; }
+// 
+//  merge into this master chunk all the events from the other_chunk with timestamps starting at merge_start_time
+//  return the merged even count
+  
+uint32_t chl::StoryChunk::mergeEvents(chl::StoryChunk & other_chunk, uint64_t merge_start_time)
+{
+    LOG_TRACE("[StoryChunk] merge StoryId{} master chunk {}-{} : merging chunk {}-{} eventCount {}", storyId, startTime,
+              endTime, other_chunk.getStartTime(), other_chunk.getEndTime(), other_chunk.getEventCount());
 
+    uint32_t merged_event_count = 0;
+
+    if( other_chunk.empty()) 
+    {  return merged_event_count; }
+
+    if( merge_start_time == 0 || merge_start_time >= other_chunk.getEndTime()) 
+    { merge_start_time = other_chunk.getStartTime(); }
+
+    std::map<chl::EventSequence, chl::LogEvent>::const_iterator first_merged, last_merged;
+
+    std::map<chl::EventSequence, chl::LogEvent>::const_iterator merge_start =
+            (merge_start_time < startTime ? other_chunk.lower_bound(startTime)
+                                          : other_chunk.lower_bound(merge_start_time));
+
+    LOG_TRACE("[StoryChunk] merge StoryId{} master chunk {} : adjusted merge_start : other_chunk {}  merge_start {}",
+              storyId, startTime, other_chunk.getStartTime(),
+              (merge_start != other_chunk.end() ? (*merge_start).second.time() : (uint64_t)0));
+
+    for(auto iter = merge_start; (iter != other_chunk.end()) && ((*iter).second.time() < endTime); ++iter)
+    {
+        LOG_TRACE("[StoryChunk] merge StoryId{} master chunk {} : merging event {}, master endTime{}", storyId,
+                  startTime, (*iter).second.time(), endTime);
+        if(insertEvent((*iter).second) > 0)
+        {
+            if(merged_event_count == 0) 
+            { first_merged = iter; }
+            last_merged = iter;
+            merged_event_count++;
+        }
+        else
+        {
+            //stop at the first record that can't be merged
+            LOG_TRACE("[StoryChunk] merge StoryId {} master chunk {} : stopped merging due to event that couldn't be "
+                      "inserted.{}",
+                      storyId, startTime, (*iter).second.time());
+            break;
+        }
+    }
+
+    if(merged_event_count > 0)
+    {
+        //remove the merged records from the original map
+        // removing recordis in range [first_merged, last_merged]
+        other_chunk.eraseEvents(first_merged, ++last_merged);
+        LOG_TRACE("[StoryChunk] merge StoryId {} master chunk {} : merged {} records from chunk {} remaining "
+                  "eventCount {}",
+                  storyId, startTime, merged_event_count, other_chunk.getStartTime(), other_chunk.getEventCount());
+    }
+    else
+    {
+        LOG_TRACE("[StoryChunk] merge StoryId {} master chunk {} : No events merged during the operation.", storyId,
+                  startTime);
+    }
+
+    return merged_event_count;
+}
+
+/*
 uint32_t chl::StoryChunk::extractEvents(std::map <chl::EventSequence, chl::LogEvent> &target_map, std::map <chl::EventSequence, chl::LogEvent>::iterator first_pos
                   , std::map <chl::EventSequence, chl::LogEvent>::iterator last_pos)
-    { return 0; }
-
-uint32_t chl::StoryChunk::extractEvents(std::map <chl::EventSequence, chl::LogEvent> &target_map, uint64_t start_time, uint64_t end_time)
     { return 0; }
 
 uint32_t chl::StoryChunk::extractEvents( chl::StoryChunk & target_chunk, uint64_t start_time, uint64_t end_time)
     { return 0; }
 
-uint32_t chl::StoryChunk::split(chl::StoryChunk & split_chunk, uint64_t time_boundary)
-    { return 0; }
+*/
 
+//
+// remove events falling into range [ range_start, range_end )  
+// return iterator to the first element folowing the last removed one
 
-uint32_t chl::StoryChunk::eraseEvents(uint64_t start_time, uint64_t end_time)
-    { return 0; }
- 
+std::map<chl::EventSequence, chl::LogEvent>::iterator
+chl::StoryChunk::eraseEvents(std::map<chl::EventSequence, chl::LogEvent>::const_iterator & range_start,
+                             std::map<chl::EventSequence, chl::LogEvent>::const_iterator & range_end)
+{
+    return logEvents.erase(range_start, range_end);
+}
+
+//
+// remove events falling into range [ start_time, end_time )  
+// return iterator to the first element folowing the last removed one
+
+std::map<chl::EventSequence, chl::LogEvent>::iterator chl::StoryChunk::eraseEvents(uint64_t start_time, uint64_t end_time)
+{
+    if( logEvents.empty() || start_time == 0 || start_time >= end_time || start_time>= endTime || end_time < startTime )
+    { return logEvents.end(); }
+
+    std::map<chl::EventSequence, chl::LogEvent>::const_iterator range_start =
+            (start_time < startTime ? logEvents.lower_bound(chl::EventSequence{startTime, 0, 0}) 
+                                    : logEvents.lower_bound(chl::EventSequence{start_time, 0, 0}));    
+
+    std::map<chl::EventSequence, chl::LogEvent>::const_iterator range_end =
+            (end_time > endTime ? logEvents.upper_bound(chl::EventSequence{endTime,0,0}) 
+                                : logEvents.upper_bound(chl::EventSequence{end_time,0,0}));
+    
+    return logEvents.erase(range_start, range_end);
+}
+
+///////////////////

--- a/chrono_common/StoryChunk.h
+++ b/chrono_common/StoryChunk.h
@@ -41,6 +41,9 @@ public:
     uint64_t getEndTime() const
     { return endTime; }
 
+    int getEventCount() const
+    { return logEvents.size(); }
+
     bool empty() const
     { return (logEvents.empty() ? true : false); }
 
@@ -54,29 +57,31 @@ public:
     { return logEvents.lower_bound(EventSequence{chrono_time, 0, 0}); }
 
     uint64_t firstEventTime() const
-    { return (*logEvents.begin()).second.time(); }
-    
+    { return (logEvents.empty() ? 0 : (*logEvents.begin()).second.time()); }
+
     uint64_t lastEventTime() const
-    { return (*logEvents.begin()).second.time(); }
+    { return (logEvents.empty() ? 0 : (*(--logEvents.end())).second.time()); }
 
     int insertEvent(LogEvent const &);
-    
-    uint32_t
-    mergeEvents(std::map <EventSequence, LogEvent> &events, std::map <EventSequence, LogEvent>::iterator &merge_start);
 
-    uint32_t mergeEvents(StoryChunk &other_chunk, uint64_t start_time =0, uint64_t end_time=0);
+    uint32_t mergeEvents(std::map<EventSequence, LogEvent> & events,
+                         std::map<EventSequence, LogEvent>::const_iterator & merge_start);
 
-    uint32_t
+    uint32_t mergeEvents(StoryChunk & other_chunk, uint64_t start_time = 0);
+
+    /*    uint32_t
     extractEvents(std::map <EventSequence, LogEvent> &target_map, std::map <EventSequence, LogEvent>::iterator first_pos
                   , std::map <EventSequence, LogEvent>::iterator last_pos);
 
     uint32_t extractEvents(std::map <EventSequence, LogEvent> &target_map, uint64_t start_time, uint64_t end_time);
 
     uint32_t extractEvents( StoryChunk & target_chunk, uint64_t start_time, uint64_t end_time);
+*/
+    std::map<EventSequence, LogEvent>::iterator
+    eraseEvents(std::map<EventSequence, LogEvent>::const_iterator & first_pos,
+                std::map<EventSequence, LogEvent>::const_iterator & last_pos);
 
-    uint32_t split(StoryChunk & split_chunk, uint64_t time_boundary);
-
-    uint32_t eraseEvents(uint64_t start_time, uint64_t end_time);
+    std::map<EventSequence, LogEvent>::iterator eraseEvents(uint64_t start_time, uint64_t end_time);
 
     // serialization function used by thallium RPC providers
     template <typename SerArchiveT>
@@ -88,7 +93,6 @@ public:
         serT & revisionTime;
         serT& logEvents;
     }
-
 
 private:
     StoryId storyId;


### PR DESCRIPTION
1. implemented and tested StoryChunk  merging logic.  it's used in ChronoGrapher to merge partial chunks coming from ChronoKeepers
2. added uniform LOG_TRACE level messages that can be used to trace merging logic of individual stories using StoryId & related timestamp boundaries  of each participating chunk
3. Adjusted const correctness of all related StoryChunk methods 