### PR TITLE
166 handle failed deserialization of partial storychunk

### DIFF
--- a/ChronoAPI/ChronoLog/include/chronolog_errcode.h
+++ b/ChronoAPI/ChronoLog/include/chronolog_errcode.h
@@ -28,7 +28,8 @@ enum ErrorCode
     CL_ERR_STORY_CHUNK_EXISTS = -17,        // Specified Story chunk exists, cannot be created
     CL_ERR_CHRONICLE_DIR_NOT_EXIST = -18,   // Chronicle directory does not exist
     CL_ERR_STORY_FILE_NOT_EXIST = -19,      // Story file does not exist
-    CL_ERR_STORY_CHUNK_DSET_NOT_EXIST = -20 // Story chunk dataset does not exist
+    CL_ERR_STORY_CHUNK_DSET_NOT_EXIST = -20,// Story chunk dataset does not exist
+    CL_ERR_STORY_CHUNK_EXTRACTION = -21,    // Error in extracting Story chunk in ChronoKeeper
 };
 }
 

--- a/ChronoGrapher/CSVFileChunkExtractor.cpp
+++ b/ChronoGrapher/CSVFileChunkExtractor.cpp
@@ -4,7 +4,6 @@
 
 #include "chronolog_types.h"
 #include "CSVFileChunkExtractor.h"
-#include "log.h"
 
 namespace tl = thallium;
 
@@ -20,7 +19,7 @@ chronolog::CSVFileStoryChunkExtractor::~CSVFileStoryChunkExtractor()
 }
 
 /////////////
-void chronolog::CSVFileStoryChunkExtractor::processStoryChunk(chronolog::StoryChunk*story_chunk)
+int chronolog::CSVFileStoryChunkExtractor::processStoryChunk(chronolog::StoryChunk*story_chunk)
 {
     std::ofstream chunk_fstream;
     std::string chunk_filename(rootDirectory);
@@ -41,5 +40,6 @@ void chronolog::CSVFileStoryChunkExtractor::processStoryChunk(chronolog::StoryCh
     }
     chunk_fstream.close();
     LOG_DEBUG("[CSVFileStoryChunkExtractor] Finished processing StoryChunk. File={}", chunk_filename);
+    return CL_SUCCESS;
 }
 

--- a/ChronoGrapher/CSVFileChunkExtractor.h
+++ b/ChronoGrapher/CSVFileChunkExtractor.h
@@ -16,7 +16,7 @@ public:
 
     ~CSVFileStoryChunkExtractor();
 
-    virtual void processStoryChunk(StoryChunk*);
+    virtual int processStoryChunk(StoryChunk*);
 
 private:
     std::string chrono_process_id;

--- a/ChronoGrapher/GrapherRecordingService.h
+++ b/ChronoGrapher/GrapherRecordingService.h
@@ -5,12 +5,12 @@
 #include <margo.h>
 #include <thallium.hpp>
 #include <thallium/serialization/stl/string.hpp>
+#include <cereal/archives/binary.hpp>
 
 #include "chronolog_errcode.h"
 #include "KeeperIdCard.h"
 #include "chronolog_types.h"
 #include "ChunkIngestionQueue.h"
-#include "../external_libs/cereal/include/cereal/archives/binary.hpp"
 
 namespace tl = thallium;
 
@@ -35,6 +35,7 @@ public:
 
     void record_story_chunk(tl::request const &request, tl::bulk &b)
     {
+        std::vector <char> mem_vec(MAX_BULK_MEM_SIZE);
         std::chrono::high_resolution_clock::time_point start, end;
         LOG_DEBUG("[GrapherRecordingService] StoryChunk recording RPC invoked, ThreadID={}", tl::thread::self_id());
         tl::endpoint ep = request.get_endpoint();
@@ -61,7 +62,16 @@ public:
 #ifndef NDEBUG
         start = std::chrono::high_resolution_clock::now();
 #endif
-        deserializedWithCereal(&mem_vec[0], b.size() - 1, *story_chunk);
+        int ret = deserializedWithCereal(&mem_vec[0], b.size() - 1, *story_chunk);
+        if(ret != CL_SUCCESS)
+        {
+            LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}", tl::thread::self_id());
+            delete story_chunk;
+            ret = 10000000 + tl::thread::self_id(); // arbitrary error code encoded with thread id
+            LOG_ERROR("[GrapherRecordingService] Discarding the story chunk, responding {} to Keeper", ret);
+            request.respond(ret);
+            return;
+        }
 #ifndef NDEBUG
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[GrapherRecordingService] Deserialization took {} us, ThreadID={}",
@@ -82,27 +92,29 @@ private:
     GrapherRecordingService(tl::engine &tl_engine, uint16_t service_provider_id, ChunkIngestionQueue &ingestion_queue)
             : tl::provider <GrapherRecordingService>(tl_engine, service_provider_id), theIngestionQueue(ingestion_queue)
     {
-        mem_vec.resize(MAX_BULK_MEM_SIZE);
+//        mem_vec.resize(MAX_BULK_MEM_SIZE);
         define("record_story_chunk", &GrapherRecordingService::record_story_chunk, tl::ignore_return_value());
         //set up callback for the case when the engine is being finalized while this provider is still alive
         get_engine().push_finalize_callback(this, [p = this]()
         { delete p; });
     }
 
-    void deserializedWithCereal(char *buffer, size_t size, StoryChunk &story_chunk)
+    int deserializedWithCereal(char *buffer, size_t size, StoryChunk &story_chunk)
     {
         try
         {
-            std::stringstream ss;
+            std::stringstream ss(std::stringstream::binary | std::stringstream::in | std::stringstream::out);
             ss.write(buffer, size);
             cereal::BinaryInputArchive iarchive(ss);
             iarchive(story_chunk);
+            return CL_SUCCESS;
         }
         catch(cereal::Exception const &ex)
         {
             LOG_ERROR("[GrapherRecordingService] Failed to deserialize a story chunk, ThreadID={}. Cereal exception "
                       "encountered.", tl::thread::self_id());
             LOG_ERROR("[GrapherRecordingService] Exception: {}", ex.what());
+            return CL_ERR_UNKNOWN;
         }
     }
 
@@ -112,7 +124,7 @@ private:
 
     ChunkIngestionQueue &theIngestionQueue;
 
-    std::vector <char> mem_vec;
+//    std::vector <char> mem_vec;
 };
 
 }// namespace chronolog

--- a/ChronoGrapher/StoryChunkExtractor.h
+++ b/ChronoGrapher/StoryChunkExtractor.h
@@ -10,6 +10,7 @@
 
 #include "chronolog_types.h"
 #include "StoryChunkExtractionQueue.h"
+#include "chronolog_errcode.h"
 #include "log.h"
 
 
@@ -46,9 +47,10 @@ public:
 
     void drainExtractionQueue();
 
-    virtual void processStoryChunk(StoryChunk*)  //=0
+    virtual int processStoryChunk(StoryChunk*)  //=0
     {
         LOG_WARNING("[StoryChunkExtraction] Base processStoryChunk method called. Derived class should implement specific logic.");
+        return CL_SUCCESS;
     }
 
     void startExtractionThreads(int);

--- a/ChronoKeeper/StoryChunkExtractor.cpp
+++ b/ChronoKeeper/StoryChunkExtractor.cpp
@@ -98,17 +98,20 @@ void chronolog::StoryChunkExtractorBase::drainExtractionQueue()
                 break;
             }
             int ret = processStoryChunk(storyChunk);
-            if(ret != chronolog::CL_SUCCESS)
-            {
-                LOG_ERROR("[StoryChunkExtractionBase] Failed to process a story chunk. ES Rank: {}, ULT ID: {}"
-                          , es.get_rank(), thallium::thread::self_id());
-                chunkExtractionQueue.stashStoryChunk(storyChunk);
-            }
-            else
+            if(ret == chronolog::CL_SUCCESS)
             {
                 LOG_DEBUG("[StoryChunkExtractionBase] Successfully processed a story chunk. ES Rank: {}, ULT ID: {}"
                           , es.get_rank(), thallium::thread::self_id());
                 delete storyChunk;
+            }
+            else
+            {
+                LOG_ERROR("[StoryChunkExtractionBase] Failed to process a story chunk, Error Code: {}. ES Rank: {}"
+                                  , ret, es.get_rank(), thallium::thread::self_id());
+                LOG_ERROR(
+                        "[StoryChunkExtractionBase] Stashing the story chunk for later processing... ES Rank: {}, ULT ID:"
+                        " {}", es.get_rank(), thallium::thread::self_id());
+                chunkExtractionQueue.stashStoryChunk(storyChunk);
             }
         }
         sleep(3);

--- a/ChronoKeeper/StoryChunkExtractorRDMA.cpp
+++ b/ChronoKeeper/StoryChunkExtractorRDMA.cpp
@@ -14,14 +14,12 @@ chronolog::StoryChunkExtractorRDMA::StoryChunkExtractorRDMA(tl::engine &extracti
 
 chronolog::StoryChunkExtractorRDMA::~StoryChunkExtractorRDMA()
 {
-    uint64_t tid = gettid();
     LOG_DEBUG("[StoryChunkExtractorRDMA] Unregistering KeeperGrapherDrainService ...");
     drain_to_grapher.deregister();
 }
 
 int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk)
 {
-    uint64_t tid = gettid();
     std::chrono::high_resolution_clock::time_point start, end;
     try
     {
@@ -31,7 +29,7 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
         start = std::chrono::high_resolution_clock::now();
 #endif
         size_t serialized_story_chunk_size;
-        std::ostringstream oss;
+        std::ostringstream oss(std::ostringstream::binary);
         try
         {
             oss.rdbuf()->pubsetbuf(serialized_buf, MAX_BULK_MEM_SIZE);
@@ -45,6 +43,7 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
             return chronolog::CL_ERR_UNKNOWN;
         }
         serialized_story_chunk_size = oss.tellp();
+        oss << '\0';
 #ifndef NDEBUG
         end = std::chrono::high_resolution_clock::now();
         LOG_INFO("[StoryChunkExtractorRDMA] Serialization took {} us",
@@ -53,7 +52,7 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
         LOG_DEBUG("[StoryChunkExtractorRDMA] Serialized story chunk size: {}", serialized_story_chunk_size);
 
         std::vector <std::pair <void*, std::size_t>> segments(1);
-        segments[0].first = (void*)(serialized_buf);
+        segments[0].first = (void*)(&serialized_buf[0]);
         segments[0].second = serialized_story_chunk_size + 1;
         tl::bulk tl_bulk = extraction_engine.expose(segments, tl::bulk_mode::read_only);
         LOG_DEBUG("[StoryChunkExtractorRDMA] Draining to Grapher with story chunk size: {} ...", tl_bulk.size());
@@ -78,13 +77,13 @@ int chronolog::StoryChunkExtractorRDMA::processStoryChunk(StoryChunk*story_chunk
         {
             LOG_ERROR("[StoryChunkExtractorRDMA] Failed to drain a story chunk to Grapher, StoryID: {}, "
                       "StartTime: {}, Error Code: {}", story_chunk->getStoryId(), story_chunk->getStartTime(), result);
-            return chronolog::CL_ERR_UNKNOWN;
+            return chronolog::CL_ERR_STORY_CHUNK_EXTRACTION;
         }
     }
     catch(tl::exception const &)
     {
         LOG_ERROR("[StoryChunkExtractorRDMA] Failed to drain a story chunk to Grapher. "
                   "Thallium exception encountered.");
+        return (chronolog::CL_ERR_UNKNOWN);
     }
-    return (chronolog::CL_ERR_UNKNOWN);
 }

--- a/ChronoVisor/src/KeeperRegistry.cpp
+++ b/ChronoVisor/src/KeeperRegistry.cpp
@@ -444,7 +444,8 @@ std::vector<KeeperIdCard>& RecordingGroup::getActiveKeepers(std::vector<KeeperId
         {
             auto dataStoreClientPair = (*iter).second.delayedExitClients.front();
             LOG_INFO("[KeeperRegistry] getActiveKeepers() destroys dataAdminClient for keeper {} current_time={} delayedExitTime={}", 
-                    (*iter).second.idCardString, ctime(&current_time));
+                    (*iter).second.idCardString, ctime(&current_time), ctime(&(*iter).second.delayedExitClients.front
+                    ().first));
             if(dataStoreClientPair.second != nullptr) { delete dataStoreClientPair.second; }
             (*iter).second.delayedExitClients.pop_front();
         }
@@ -997,7 +998,7 @@ int KeeperRegistry::unregisterGrapherProcess(GrapherIdCard const& grapher_id_car
 
         std::time_t delayedExitTime = std::chrono::high_resolution_clock::to_time_t(
                 std::chrono::high_resolution_clock::now() + std::chrono::seconds(delayedDataAdminExitSeconds));
-        LOG_INFO("[KeeperRegistry] grapher {} starting delayedExit for grapher {} delayedExitTime={}", recording_group.grapherProcess->idCardString,
+        LOG_INFO("[KeeperRegistry] starting delayedExit for grapher {} delayedExitTime={}", recording_group.grapherProcess->idCardString,
                  std::ctime(&delayedExitTime));
 
         recording_group.startDelayedGrapherExit(*(recording_group.grapherProcess), delayedExitTime);


### PR DESCRIPTION
Grapher returns an error code to Keeper on failure of story chunk deserialization
Keeper re-stashes the story chunk back to extract queue to try another time later when error code is returned from extraction RPC