### PR TITLE
Add read mode to client_admin

### DIFF
--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -110,7 +110,7 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char **argv)
     // Define the long options and their corresponding short options
     struct option long_options[] = {{  "config"            , required_argument, nullptr, 'c'}
                                     , {"interactive"       , optional_argument, nullptr, 'i'}
-                                    , {"write"             , optional_argument, nullptr, 'w'}
+                                    , {"write"             , no_argument       , nullptr, 'w'}
                                     , {"read"              , optional_argument, nullptr, 'r'}
                                     , {"chronicle_count"   , required_argument, nullptr, 'h'}
                                     , {"story_count"       , required_argument, nullptr, 't'}

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -1068,7 +1068,7 @@ std::vector <std::string> &command_subs)
                     replay_story_bw = (double)total_event_payload_size / replayStoryTimer.getDuration() / 1e6;
                     replay_story_thpt = (double)workload_args.event_count * size / replayStoryTimer.getDuration() / 1e6;
                 }
-                else if(workload_args.read)
+                else
                 {
                     record_event_bw = (double)total_event_payload_size / writeEventTimer.getDuration() / 1e6;
                     record_event_thpt = (double)workload_args.event_count * size / writeEventTimer.getDuration() / 1e6;

--- a/Client/ChronoAdmin/client_admin.cpp
+++ b/Client/ChronoAdmin/client_admin.cpp
@@ -1,6 +1,5 @@
 #include <chronolog_client.h>
 #include <cmd_arg_parse.h>
-#include <chronolog_client.h>
 #include <ClientConfiguration.h>
 #include <common.h>
 #include <cassert>
@@ -13,7 +12,6 @@
 #include <mpi.h>
 #include <chrono_monitor.h>
 #include <TimerWrapper.h>
-#include <cstring>
 #include <margo.h>
 
 #define MAX_EVENT_SIZE (32 * 1024 * 1024)
@@ -30,26 +28,31 @@ typedef struct workload_conf_args_
     bool barrier = false;
     std::string event_payload_file;
     bool interactive = false;
+    bool write = true;
+    bool read = false;
     bool shared_story = false;
     bool perf_test = false;
 } workload_conf_args;
 
-void usage(char**argv)
+void usage(char **argv)
 {
     std::cerr << "\nUsage: " << argv[0] << " [options]\n"
-                 "-c|--config <config_file>\n"
-                 "-i|--interactive\n"
-                 "-h|--chronicle_count <chronicle_count>\n"
-                 "-t|--story_count <story_count>\n"
-                 "-a|--min_event_size <min_event_size>\n"
-                 "-s|--ave_event_size <ave_event_size>\n"
-                 "-b|--max_event_size <max_event_size>\n"
-                 "-n|--event_count <event_count>\n"
-                 "-g|--event_interval <event_interval>\n"
-                 "-r|--barrier\n"
-                 "-f|--event_payload_file <event_payload_file>\n"
-                 "-o|--shared_story\n"
-                 "-p|--perf\n" << argv[0] << std::endl;
+                                           "-c|--config <config_file>\n"
+                                           "-i|--interactive\tInteract with ChronoLog like a shell\n"
+                                           "-w|--write\t\tRecord events\n"
+                                           "-r|--read\t\tRetrieve events\n"
+                                           "-h|--chronicle_count <chronicle_count_per_proc>\n"
+                                           "-t|--story_count <story_count_per_proc>\n"
+                                           "-a|--min_event_size <min_event_size_in_byte>\n"
+                                           "-s|--ave_event_size <ave_event_size_in_byte>\n"
+                                           "-b|--max_event_size <max_event_size_in_byte>\n"
+                                           "-n|--event_count <event_count_per_proc>\n"
+                                           "-g|--event_interval <event_interval_in_us>\n"
+                                           "-y|--barrier\t\tHold next API call until completion of previous one\n"
+                                           "-f|--event_payload_file <event_payload_file>\n"
+                                           "-o|--shared_story\tAll procs record events to the same chronicle\n"
+                                           "-p|--perf\t\tReport performance metrics after completion\n"
+                                           "-u|--usage\t\tPrint this page\n" << std::endl;
 }
 
 void random_sleep()
@@ -95,33 +98,36 @@ uint64_t get_uint64_t_from_string(const std::string &str)
     return value;
 }
 
-std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
+std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char **argv)
 {
-    int rank;
+    int rank, size;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
     int opt;
-    char*config_file = nullptr;
+    char *config_file = nullptr;
     workload_conf_args workload_args;
 
     // Define the long options and their corresponding short options
-    struct option long_options[] = {{  "config"              , required_argument, nullptr, 'c'}
-                                    , {"interactive"         , optional_argument, nullptr, 'i'}
-                                    , {"chronicle_count"     , required_argument, nullptr, 'h'}
-                                    , {"story_count"         , required_argument, nullptr, 't'}
-                                    , {"min_event_size"      , required_argument, nullptr, 'a'}
-                                    , {"ave_event_size"      , required_argument, nullptr, 's'}
-                                    , {"max_event_size"      , required_argument, nullptr, 'b'}
-                                    , {"event_count"         , required_argument, nullptr, 'n'}
-                                    , {"event_interval"      , required_argument, nullptr, 'g'}
-                                    , {"barrier"             , optional_argument, nullptr, 'r'}
-                                    , {"event_payload_file"  , optional_argument, nullptr, 'f'}
-                                    , {"shared_story"        , optional_argument, nullptr, 'o'}
-                                    , {"perf"                , optional_argument, nullptr, 'p'}
-                                    , {nullptr               , 0                , nullptr, 0}
-    };
+    struct option long_options[] = {{  "config"            , required_argument, nullptr, 'c'}
+                                    , {"interactive"       , optional_argument, nullptr, 'i'}
+                                    , {"write"             , optional_argument, nullptr, 'w'}
+                                    , {"read"              , optional_argument, nullptr, 'r'}
+                                    , {"chronicle_count"   , required_argument, nullptr, 'h'}
+                                    , {"story_count"       , required_argument, nullptr, 't'}
+                                    , {"min_event_size"    , required_argument, nullptr, 'a'}
+                                    , {"ave_event_size"    , required_argument, nullptr, 's'}
+                                    , {"max_event_size"    , required_argument, nullptr, 'b'}
+                                    , {"event_count"       , required_argument, nullptr, 'n'}
+                                    , {"event_interval"    , required_argument, nullptr, 'g'}
+                                    , {"barrier"           , optional_argument, nullptr, 'y'}
+                                    , {"event_payload_file", optional_argument, nullptr, 'f'}
+                                    , {"shared_story"      , optional_argument, nullptr, 'o'}
+                                    , {"perf"              , optional_argument, nullptr, 'p'}
+                                    , {"usage"             , no_argument       , nullptr, 'u'}
+                                    , {nullptr             , 0                , nullptr, 0}};
 
     // Parse the command-line options
-    while((opt = getopt_long(argc, argv, "c:ih:t:a:s:b:n:g:rf:op", long_options, nullptr)) != -1)
+    while((opt = getopt_long(argc, argv, "c:iwrh:t:a:s:b:n:g:yf:opu", long_options, nullptr)) != -1)
     {
         switch(opt)
         {
@@ -130,6 +136,13 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
                 break;
             case 'i':
                 workload_args.interactive = true;
+                break;
+            case 'w':
+                workload_args.write = true;
+                break;
+            case 'r':
+                workload_args.read = true;
+                workload_args.write = false; // read mode has higher priority than write mode
                 break;
             case 'h':
                 workload_args.chronicle_count = get_uint64_t_from_string(optarg);
@@ -152,7 +165,7 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
             case 'g':
                 workload_args.event_interval = get_uint64_t_from_string(optarg);
                 break;
-            case 'r':
+            case 'y':
                 workload_args.barrier = true;
                 break;
             case 'f':
@@ -164,6 +177,13 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
             case 'p':
                 workload_args.perf_test = true;
                 break;
+            case 'u':
+                // Print usage information
+                if(rank == 0)
+                {
+                    usage(argv);
+                }
+                exit(EXIT_SUCCESS);
             case '?':
                 // Invalid option or missing argument
                 usage(argv);
@@ -188,27 +208,32 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
             else
             {
                 std::cout << "Interactive mode: off" << std::endl;
-                std::cout << "Chronicle count: " << workload_args.chronicle_count << std::endl;
-                std::cout << "Story count: " << workload_args.story_count << std::endl;
+                std::cout << "Number of processes: " << size << std::endl;
+                std::cout << "Chronicle count (#chronicles per proc): " << workload_args.chronicle_count << std::endl;
+                std::cout << "Story count (#stories per proc): " << workload_args.story_count << std::endl;
                 if(!workload_args.event_payload_file.empty())
                 {
-                    std::cout << "Event payload file specified: " << workload_args.event_payload_file.c_str()
-                              << std::endl;
-                    std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
-                    std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+                    std::cout << "Event payload file specified (event payloads in lines): "
+                        << workload_args.event_payload_file.c_str() << std::endl;
                 }
                 else
                 {
-                    std::cout << "No event input file specified, use default/specified separate conf args ..."
-                              << std::endl;
-                    std::cout << "Min event size: " << workload_args.min_event_size << std::endl;
-                    std::cout << "Ave event size: " << workload_args.ave_event_size << std::endl;
-                    std::cout << "Max event size: " << workload_args.max_event_size << std::endl;
-                    std::cout << "Event count: " << workload_args.event_count << std::endl;
-                    std::cout << "Event interval: " << workload_args.event_interval << std::endl;
-                    std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
-                    std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+                    std::cout << "No event payload file specified, use default/specified separate conf args ..."
+                        << std::endl;
+                    std::cout << "Min event size (minimum of event payload length following a normal distribution): "
+                        << workload_args.min_event_size << " bytes" << std::endl;
+                    std::cout << "Ave event size (median of event payload length following a normal distribution): "
+                        << workload_args.ave_event_size << " bytes" << std::endl;
+                    std::cout << "Max event size (maximum of event payload length following a normal distribution): "
+                        << workload_args.max_event_size << " bytes" << std::endl;
+                    std::cout << "Event count (#events per proc): " << workload_args.event_count << std::endl;
+                    std::cout << "Event interval (time in-between event accesses): "
+                        << workload_args.event_interval << " us" << std::endl;
                 }
+                std::cout << "Barrier (hold on next ChronoLog API call until completion of the previous one): "
+                          << (workload_args.barrier ? "true" : "false") << std::endl;
+                std::cout << "Shared story (all procs access the same story): "
+                          << (workload_args.shared_story ? "true" : "false") << std::endl;
             }
         }
         return {std::pair <std::string, workload_conf_args>((config_file), workload_args)};
@@ -219,15 +244,22 @@ std::pair <std::string, workload_conf_args> cmd_arg_parse(int argc, char**argv)
         {
             std::cout << "No config file specified, using default settings instead:" << std::endl;
             std::cout << "Interactive mode: " << (workload_args.interactive ? "on" : "off") << std::endl;
-            std::cout << "Chronicle count: " << workload_args.chronicle_count << std::endl;
-            std::cout << "Story count: " << workload_args.story_count << std::endl;
-            std::cout << "Min event size: " << workload_args.min_event_size << std::endl;
-            std::cout << "Ave event size: " << workload_args.ave_event_size << std::endl;
-            std::cout << "Max event size: " << workload_args.max_event_size << std::endl;
-            std::cout << "Event count: " << workload_args.event_count << std::endl;
-            std::cout << "Event interval: " << workload_args.event_interval << std::endl;
-            std::cout << "Barrier: " << (workload_args.barrier ? "true" : "false") << std::endl;
-            std::cout << "Shared story: " << (workload_args.shared_story ? "true" : "false") << std::endl;
+            std::cout << "Number of processes: " << size << std::endl;
+            std::cout << "Chronicle count (#chronicles per proc): " << workload_args.chronicle_count << std::endl;
+            std::cout << "Story count (#stories per proc) : " << workload_args.story_count << std::endl;
+            std::cout << "Min event size (minimum of event payload length following a normal distribution): "
+                << workload_args.min_event_size << " bytes" << std::endl;
+            std::cout << "Ave event size (median of event payload length following a normal distribution): "
+                << workload_args.ave_event_size << " bytes" << std::endl;
+            std::cout << "Max event size (maximum of event payload length following a normal distribution): "
+                << workload_args.max_event_size << " bytes" << std::endl;
+            std::cout << "Event count (#events per proc): " << workload_args.event_count << std::endl;
+            std::cout << "Event interval (time in-between event accesses): "
+                << workload_args.event_interval << " us" << std::endl;
+            std::cout << "Barrier (hold on next data access until completion of the previous one): "
+                << (workload_args.barrier ? "true" : "false") << std::endl;
+            std::cout << "Shared story (all procs access the same story): "
+                << (workload_args.shared_story ? "true" : "false") << std::endl;
         }
         return {"", workload_args};
     }
@@ -245,7 +277,7 @@ int test_create_chronicle(chronolog::Client &client, const std::string &chronicl
     return ret;
 }
 
-chronolog::StoryHandle*
+std::pair <int, chronolog::StoryHandle *>
 test_acquire_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
 {
 //    random_sleep();
@@ -254,23 +286,30 @@ test_acquire_story(chronolog::Client &client, const std::string &chronicle_name,
     story_acquisition_attrs.emplace("Priority", "High");
     story_acquisition_attrs.emplace("IndexGranularity", "Millisecond");
     story_acquisition_attrs.emplace("TieringPolicy", "Hot");
-    std::pair <int, chronolog::StoryHandle*> acq_ret = client.AcquireStory(chronicle_name, story_name
-                                                                           , story_acquisition_attrs, flags);
+    std::pair <int, chronolog::StoryHandle *> acq_ret = client.AcquireStory(chronicle_name, story_name
+                                                                            , story_acquisition_attrs, flags);
 //    LOG_DEBUG("acq_ret: {}", to_string_client(acq_ret.first));
-    assert(acq_ret.first == chronolog::CL_SUCCESS || acq_ret.first == chronolog::CL_ERR_ACQUIRED);
-    return acq_ret.second;
+//    assert(acq_ret.first == chronolog::CL_SUCCESS || acq_ret.first == chronolog::CL_ERR_ACQUIRED);
+    return acq_ret;
 }
 
-uint64_t test_write_event(chronolog::StoryHandle*story_handle, const std::string &event_payload)
+uint64_t test_write_event(chronolog::StoryHandle *story_handle, const std::string &event_payload)
 {
     uint64_t ret = story_handle->log_event(event_payload);
     assert(ret > 0);
     return ret;
 }
 
+int test_replay_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name
+                      , uint64_t start_time, uint64_t end_time, std::vector <chronolog::Event> &replay_events)
+{
+    int ret = client.ReplayStory(chronicle_name, story_name, start_time, end_time, replay_events);
+    assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST);
+    return ret;
+}
+
 int test_release_story(chronolog::Client &client, const std::string &chronicle_name, const std::string &story_name)
 {
-    random_sleep(); // TODO: (Kun) remove this when the hanging bug upon concurrent acquire is fixed
     int ret = client.ReleaseStory(chronicle_name, story_name);
     assert(ret == chronolog::CL_SUCCESS || ret == chronolog::CL_ERR_NOT_EXIST);
     return ret;
@@ -389,7 +428,7 @@ uint64_t get_event_timestamp(std::string &event_line)
     std::tm timeinfo{};
     auto now = std::chrono::system_clock::now();
     std::time_t current_time = std::chrono::system_clock::to_time_t(now);
-    std::tm*time_info_now = std::localtime(&current_time);
+    std::tm *time_info_now = std::localtime(&current_time);
     // assume the log file is generated in the same year as the current time
     timeinfo.tm_year = time_info_now->tm_year;
     strptime(timestamp_str.c_str(), "%b %d %H:%M:%S", &timeinfo);
@@ -406,7 +445,223 @@ uint64_t get_bigbang_timestamp(std::ifstream &file)
     return bigbang_timestamp;
 }
 
-int main(int argc, char**argv)
+void interactive_create_chronicle(std::vector <std::string> &tokens, chronolog::Client &client)
+{
+    if(tokens.size() != 2)
+    {
+        std::cerr << "Usage: -c <chronicle_name>" << std::endl;
+        return;
+    }
+    int ret_i;
+    const std::string& chronicle_name = tokens[1];
+    ret_i = test_create_chronicle(client, chronicle_name);
+    if(ret_i == chronolog::CL_SUCCESS)
+    {
+        std::cout << "Chronicle created successfully: " << chronicle_name << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_CHRONICLE_EXISTS)
+    {
+        std::cout << "Chronicle already exists: " << chronicle_name << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to create Chronicle: " << chronicle_name
+                  << ", return code: " << chronolog::to_string_client(ret_i) << std::endl;
+    }
+}
+
+chronolog::StoryHandle* interactive_acquire_story(std::vector <std::string> &tokens, chronolog::Client &client)
+{
+    if(tokens.size() != 4)
+    {
+        std::cerr << "Usage: -a -s <chronicle_name> <story_name>" << std::endl;
+        return nullptr;
+    }
+    int ret_i;
+    chronolog::StoryHandle *story_handle = nullptr;
+    const std::string &chronicle_name = tokens[2];
+    const std::string &story_name = tokens[3];
+    auto ret = test_acquire_story(client, chronicle_name, story_name);
+    ret_i = ret.first;
+    story_handle = ret.second;
+    if(ret_i == chronolog::CL_SUCCESS)
+    {
+        std::cout << "Story acquired successfully: " << story_name << " in Chronicle "
+                  << chronicle_name << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_ACQUIRED)
+    {
+        std::cout << "Story already acquired: " << story_name << " in Chronicle " << chronicle_name
+                  << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
+    {
+        std::cout << "Chronicle does not exist: " << chronicle_name << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to acquire story: " << story_name << " in Chronicle " << chronicle_name
+                  << ", return code: " << chronolog::to_string_client(ret_i) << std::endl;
+    }
+    return story_handle;
+}
+
+void interactive_release_story(std::vector <std::string> &tokens, chronolog::Client &client)
+{
+    if(tokens.size() != 4)
+    {
+        std::cerr << "Usage: -q -s <chronicle_name> <story_name>" << std::endl;
+        return;
+    }
+    int ret_i;
+    const std::string& chronicle_name = tokens[2];
+    const std::string& story_name = tokens[3];
+    ret_i = test_release_story(client, chronicle_name, story_name);
+    if(ret_i == chronolog::CL_SUCCESS)
+    {
+        std::cout << "Story released successfully: " << story_name << " in Chronicle "
+                  << chronicle_name << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
+    {
+        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name
+                  << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to release story: " << story_name << " in Chronicle " << chronicle_name
+                  << ", return code: " << chronolog::to_string_client(ret_i) << std::endl;
+    }
+}
+
+void interactive_write_event(std::vector <std::string> &tokens, chronolog::StoryHandle *story_handle)
+{
+    if(tokens.size() < 2)
+    {
+        std::cerr << "Usage: -w <event_payload>" << std::endl;
+        return;
+    }
+    uint64_t ret_u;
+    std::string event_payload;
+    for(size_t i = 1; i < tokens.size(); ++i)
+    {
+        if(i > 1)
+        {
+            event_payload += " ";
+        }
+        event_payload += tokens[i];
+    }
+    ret_u = test_write_event(story_handle, event_payload);
+    if(ret_u > 0)
+    {
+        std::cout << "Event written successfully, payload length: " << event_payload.length()
+                  << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to write event, return code: " << ret_u << std::endl;
+    }
+}
+
+void interactive_replay_story(std::vector <std::string> &tokens, chronolog::Client &client)
+{
+    if(tokens.size() != 5)
+    {
+        std::cerr << "Usage: -r -s <chronicle_name> <story_name> <start_time> <end_time>" << std::endl;
+        return;
+    }
+    int ret_i;
+    const std::string& chronicle_name = tokens[1];
+    const std::string& story_name = tokens[2];
+    uint64_t start_time = get_uint64_t_from_string(tokens[3]);
+    uint64_t end_time = get_uint64_t_from_string(tokens[4]);
+    std::vector <chronolog::Event> replay_events;
+    ret_i = test_replay_story(client, chronicle_name, story_name, start_time, end_time, replay_events);
+    if(ret_i == chronolog::CL_SUCCESS)
+    {
+        std::cout << "Replay successful, retrieved " << replay_events.size() << " events from "
+                  << chronicle_name << " story " << story_name << " between "
+                  << start_time << " and " << end_time << std::endl;
+        for(const auto &event: replay_events)
+        {
+            std::cout << event.to_string() << std::endl;
+        }
+    }
+    else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
+    {
+        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name
+                  << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to replay story: " << story_name << " in Chronicle " << chronicle_name
+                  << ", return code: " << chronolog::to_string_client(ret_i) << std::endl;
+    }
+}
+
+void interactive_destroy_story(std::vector <std::string> &tokens, chronolog::Client &client)
+{
+    if(tokens.size() != 4)
+    {
+        std::cerr << "Usage: -d -s <chronicle_name> <story_name>" << std::endl;
+        return;
+    }
+    int ret_i;
+    const std::string& chronicle_name = tokens[2];
+    const std::string& story_name = tokens[3];
+    ret_i = test_destroy_story(client, chronicle_name, story_name);
+    if(ret_i == chronolog::CL_SUCCESS)
+    {
+        std::cout << "Story destroyed successfully: " << story_name << " in Chronicle "
+                  << chronicle_name << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_ACQUIRED)
+    {
+        std::cout << "Story is still acquired, cannot destroy: " << story_name << " in Chronicle "
+                  << chronicle_name << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
+    {
+        std::cout << "Story does not exist: " << story_name << " in Chronicle " << chronicle_name
+                  << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to destroy Story: " << story_name << " in Chronicle " << chronicle_name
+                  << ", return code: " << chronolog::to_string_client(ret_i) << std::endl;
+    }
+}
+
+void interactive_destroy_chronicle(std::vector <std::string> &tokens, chronolog::Client &client)
+{
+    if(tokens.size() != 3)
+    {
+        std::cerr << "Usage: -d -c <chronicle_name>" << std::endl;
+        return;
+    }
+    int ret_i;
+    const std::string& chronicle_name = tokens[2];
+    ret_i = test_destroy_chronicle(client, chronicle_name);
+    if(ret_i == chronolog::CL_SUCCESS)
+    {
+        std::cout << "Chronicle destroyed successfully: " << chronicle_name << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_ACQUIRED)
+    {
+        std::cout << "Chronicle is still acquired, cannot destroy: " << chronicle_name << std::endl;
+    }
+    else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
+    {
+        std::cout << "Chronicle does not exist: " << chronicle_name << std::endl;
+    }
+    else
+    {
+        std::cout << "Failed to destroy Chronicle: " << chronicle_name
+                  << ", return code: " << chronolog::to_string_client(ret_i) << std::endl;
+    }
+}
+
+int main(int argc, char **argv)
 {
     std::string argobots_conf_str = R"({"argobots" : {"abt_mem_max_num_stacks" : 8
                                                     , "abt_thread_stacksize" : 2097152}})";
@@ -417,45 +672,65 @@ int main(int argc, char**argv)
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
-    std::pair<std::string, workload_conf_args> cmd_args = cmd_arg_parse(argc, argv);
+    std::pair <std::string, workload_conf_args> cmd_args = cmd_arg_parse(argc, argv);
     std::string conf_file_path = cmd_args.first;
     workload_conf_args workload_args = cmd_args.second;
 
     chronolog::ClientConfiguration confManager;
-    if (!conf_file_path.empty()) {
-        if (!confManager.load_from_file(conf_file_path)) {
-            std::cerr << "[ClientAdmin] Failed to load configuration file '" << conf_file_path << "'. Using default values instead." << std::endl;
-        } else {
-            std::cout << "[ClientAdmin] Configuration file loaded successfully from '" << conf_file_path << "'." << std::endl;
+    if(!conf_file_path.empty())
+    {
+        if(!confManager.load_from_file(conf_file_path))
+        {
+            std::cerr << "[ClientAdmin] Failed to load configuration file '" << conf_file_path
+                      << "'. Using default values instead." << std::endl;
         }
-    } else {
+        else
+        {
+            std::cout << "[ClientAdmin] Configuration file loaded successfully from '" << conf_file_path << "'."
+                      << std::endl;
+        }
+    }
+    else
+    {
         std::cout << "[ClientAdmin] No configuration file provided. Using default values." << std::endl;
     }
-    
-    if (rank == 0) {
-    confManager.log_configuration(std::cout);
+
+    if(rank == 0)
+    {
+        confManager.log_configuration(std::cout);
     }
 
     // Initialize logging
-    int result = chronolog::chrono_monitor::initialize(confManager.LOG_CONF.LOGTYPE,
-                                                       confManager.LOG_CONF.LOGFILE,
-                                                       confManager.LOG_CONF.LOGLEVEL,
-                                                       confManager.LOG_CONF.LOGNAME,
-                                                       confManager.LOG_CONF.LOGFILESIZE,
-                                                       confManager.LOG_CONF.LOGFILENUM,
-                                                       confManager.LOG_CONF.FLUSHLEVEL);
+    int result = chronolog::chrono_monitor::initialize(confManager.LOG_CONF.LOGTYPE, confManager.LOG_CONF.LOGFILE
+                                                       , confManager.LOG_CONF.LOGLEVEL, confManager.LOG_CONF.LOGNAME
+                                                       , confManager.LOG_CONF.LOGFILESIZE
+                                                       , confManager.LOG_CONF.LOGFILENUM
+                                                       , confManager.LOG_CONF.FLUSHLEVEL);
 
-    if (result == 1) {
+    if(result == 1)
+    {
         exit(EXIT_FAILURE);
     }
 
-    chronolog::Client client(confManager.PORTAL_CONF);
-    chronolog::StoryHandle* story_handle;
+    if(workload_args.read)
+    {
+        std::cout << "[ClientAdmin] Running in read mode." << std::endl;
+    }
+    else
+    {
+        std::cout << "[ClientAdmin] Running in write mode." << std::endl;
+    }
+
+    chronolog::Client client = workload_args.read ?
+                               chronolog::Client(confManager.PORTAL_CONF, confManager.QUERY_CONF) :
+                               chronolog::Client(confManager.PORTAL_CONF);
+    chronolog::StoryHandle *story_handle;
 
     TimerWrapper connectTimer(workload_args.perf_test, "Connect");
     TimerWrapper createChronicleTimer(workload_args.perf_test, "CreateChronicle");
     TimerWrapper acquireStoryTimer(workload_args.perf_test, "AcquireStory");
     TimerWrapper writeEventTimer(workload_args.perf_test, "WriteEvent");
+    TimerWrapper replayStoryTimer(workload_args.perf_test, "ReplayStory");
     TimerWrapper releaseStoryTimer(workload_args.perf_test, "ReleaseStory");
     TimerWrapper destroyStoryTimer(workload_args.perf_test, "DestroyStory");
     TimerWrapper destroyChronicleTimer(workload_args.perf_test, "DestroyChronicle");
@@ -468,8 +743,8 @@ int main(int argc, char**argv)
     std::string client_id = gen_random(8);
 //    std::cout << "Generated client id: " << client_id << std::endl;
 
-    const std::string& server_protoc = confManager.PORTAL_CONF.PROTO_CONF;
-    const std::string& server_ip = confManager.PORTAL_CONF.IP;
+    const std::string &server_protoc = confManager.PORTAL_CONF.PROTO_CONF;
+    const std::string &server_ip = confManager.PORTAL_CONF.IP;
     std::string server_port = std::to_string(confManager.PORTAL_CONF.PORT);
     std::string server_provider_id = std::to_string(confManager.PORTAL_CONF.PROVIDER_ID);
     std::string server_address = server_protoc + "://" + server_ip + ":" + server_port + "@" + server_provider_id;
@@ -488,6 +763,8 @@ int main(int argc, char**argv)
         std::cout << "Metadata operations: \n" << "\t-c <chronicle_name> , create a Chronicle <chronicle_name>\n"
                   << "\t-a -s <chronicle_name> <story_name>, acquire Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-w <event_string>, write Event with <event_string> as payload\n"
+                  << "\t-r <chronicle_name> <story_name> <start_time> <end_time>, read Events in Story <story_name> of "
+                     "Chronicle <chronicle_name> from <start_time> to <end_time>\n"
                   << "\t-q -s <chronicle_name> <story_name>, release Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-d -s <chronicle_name> <story_name>, destroy Story <story_name> in Chronicle <chronicle_name>\n"
                   << "\t-d -c <chronicle_name>, destroy Chronicle <chronicle_name>\n" << "\t-disconnect\n" << std::endl;
@@ -495,28 +772,14 @@ int main(int argc, char**argv)
         std::unordered_map <std::string, std::function <void(std::vector <std::string> &)>> command_map = {{  "-c", [&](
 std::vector <std::string> &command_subs)
         {
-            assert(command_subs.size() == 2);
-            std::string chronicle_name = command_subs[1];
-            ret_i = test_create_chronicle(client, chronicle_name);
-            if(ret_i == chronolog::CL_SUCCESS)
-            {
-                std::cout << "Chronicle created successfully: " << chronicle_name << std::endl;
-            }
+            interactive_create_chronicle(command_subs, client);
         }}
                                                                                                            , {"-a", [&](
                         std::vector <std::string> &command_subs)
                 {
                     if(command_subs[1] == "-s")
                     {
-                        assert(command_subs.size() == 4);
-                        std::string chronicle_name = command_subs[2];
-                        std::string story_name = command_subs[3];
-                        story_handle = test_acquire_story(client, chronicle_name, story_name);
-                        if(story_handle)
-                        {
-                            std::cout << "Story acquired successfully: " << story_name << " in Chronicle "
-                                      << chronicle_name << std::endl;
-                        }
+                        story_handle = interactive_acquire_story(command_subs, client);
                     }
                 }}
                                                                                                            , {"-q", [&](
@@ -524,76 +787,29 @@ std::vector <std::string> &command_subs)
                 {
                     if(command_subs[1] == "-s")
                     {
-                        assert(command_subs.size() == 4);
-                        std::string chronicle_name = command_subs[2];
-                        std::string story_name = command_subs[3];
-                        ret_i = test_release_story(client, chronicle_name, story_name);
-                        if(ret_i == chronolog::CL_SUCCESS)
-                        {
-                            std::cout << "Story released successfully: " << story_name << " in Chronicle "
-                                      << chronicle_name << std::endl;
-                        }
-                        else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
-                        {
-                            std::cout << "Story does not exist: " << story_name << " in Chronicle "
-                                      << chronicle_name << std::endl;
-                        }
+                        interactive_release_story(command_subs, client);
                     }
                 }}
                                                                                                            , {"-w", [&](
                         std::vector <std::string> &command_subs)
                 {
-                    assert(command_subs.size() == 2);
-                    std::string event_payload = command_subs[1];
-                    ret_u = test_write_event(story_handle, event_payload);
-                    if(ret_u > 0)
-                    {
-                        std::cout << "Event written successfully, payload length: " << event_payload.length()
-                                  << std::endl;
-                    }
+                    interactive_write_event(command_subs, story_handle);
+                }}
+                                                                                                           , {"-r", [&](
+                        std::vector <std::string> &command_subs)
+                {
+                    interactive_replay_story(command_subs, client);
                 }}
                                                                                                            , {"-d", [&](
                         std::vector <std::string> &command_subs)
                 {
                     if(command_subs[1] == "-c")
                     {
-                        assert(command_subs.size() == 3);
-                        std::string chronicle_name = command_subs[2];
-                        ret_i = test_destroy_chronicle(client, chronicle_name);
-                        if(ret_i == chronolog::CL_SUCCESS)
-                        {
-                            std::cout << "Chronicle destroyed successfully: " << chronicle_name << std::endl;
-                        }
-                        else if(ret_i == chronolog::CL_ERR_ACQUIRED)
-                        {
-                            std::cout << "Chronicle is still acquired, cannot destroy: " << chronicle_name << std::endl;
-                        }
-                        else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
-                        {
-                            std::cout << "Chronicle does not exist: " << chronicle_name << std::endl;
-                        }
+                        interactive_destroy_chronicle(command_subs, client);
                     }
                     else if(command_subs[1] == "-s")
                     {
-                        assert(command_subs.size() == 4);
-                        std::string chronicle_name = command_subs[2];
-                        std::string story_name = command_subs[3];
-                        ret_i = test_destroy_story(client, chronicle_name, story_name);
-                        if(ret_i == chronolog::CL_SUCCESS)
-                        {
-                            std::cout << "Story destroyed successfully: " << story_name << " in Chronicle "
-                                      << chronicle_name << std::endl;
-                        }
-                        else if(ret_i == chronolog::CL_ERR_ACQUIRED)
-                        {
-                            std::cout << "Story is still acquired, cannot destroy: " << story_name << " in Chronicle "
-                                      << chronicle_name << std::endl;
-                        }
-                        else if(ret_i == chronolog::CL_ERR_NOT_EXIST)
-                        {
-                            std::cout << "Story does not exist: " << story_name << " in Chronicle "
-                                      << chronicle_name << std::endl;
-                        }
+                        interactive_destroy_story(command_subs, client);
                     }
                 }}};
 
@@ -637,101 +853,156 @@ std::vector <std::string> &command_subs)
                     story_name = "story_" + std::to_string(j);
                 else
                     story_name = "story_" + std::to_string(rank) + "_" + std::to_string(j);
-                story_handle = acquireStoryTimer.timeBlock(test_acquire_story, client, chronicle_name, story_name);
+                auto ret = acquireStoryTimer.timeBlock(test_acquire_story, client, chronicle_name, story_name);
+                ret_i = ret.first;
+                story_handle = ret.second;
+                if(workload_args.write && ret_i != chronolog::CL_SUCCESS)
+                {
+                    std::cerr << "Failed to acquire story: " << story_name << " in Chronicle: " << chronicle_name
+                                                             << ", ret: " << chronolog::to_string_client(ret_i)
+                                                             << std::endl;
+                    exit(EXIT_FAILURE);
+                }
+                else if(workload_args.read && ret_i == chronolog::CL_ERR_NOT_EXIST)
+                {
+                    std::cerr << "Story does not exist: " << story_name << " in Chronicle: " << chronicle_name
+                                                          << ", ret: " << chronolog::to_string_client(ret_i)
+                                                          << std::endl;
+                    std::cout << "Please make sure a write test with the same configuration is executed before the read test."
+                              << std::endl;
+                    exit(EXIT_FAILURE);
+                }
+//                std::cout << "Return value of AcquireStory: " << chronolog::to_string_client(ret_i) << std::endl;
                 if(workload_args.barrier)
                     MPI_Barrier(MPI_COMM_WORLD);
 
-                // write event test
-                std::string event_payload;
-                writeEventTimer.timeBlock([&]()
-                                {
-                                    uint64_t event_count_per_story =
-                                            workload_args.event_count / workload_args.story_count;
-                                    for(uint64_t k = 0; k < event_count_per_story; k++)
-                                    {
-                                        if(workload_args.event_payload_file.empty())
-                                        {
-                                            // randomly generate events size if range is specified
-                                            writeEventTimer.pauseTimer();
+                if(workload_args.read)
+                {
+                    // replay story test
+                    uint64_t start_time = 0, end_time = UINT64_MAX;
+                    std::vector <chronolog::Event> replay_events;
+                    uint64_t event_count_per_story =
+                            workload_args.event_count / workload_args.story_count;
+                    event_payload_size_per_rank = 0;
+                    replayStoryTimer.timeBlock([&]()
+                                               {
+                                                   for(uint64_t k = 0; k < event_count_per_story; k++)
+                                                   {
+                                                       ret_u = test_replay_story(client, chronicle_name, story_name, start_time, end_time
+                                                                                 , replay_events);
+                                                       replayStoryTimer.pauseTimer();
+                                                       for(const auto &event: replay_events)
+                                                       {
+                                                           event_payload_size_per_rank += event.log_record().size();
+                                                       }
 
-                                            uint64_t event_size;
-                                            if(workload_args.ave_event_size == workload_args.min_event_size &&
-                                               workload_args.ave_event_size == workload_args.max_event_size)
-                                            {
-                                                event_size = workload_args.ave_event_size;
-                                            }
-                                            else
-                                            {
-                                                event_size = (unsigned long)std::min(std::max(size_dist(gen),
-                                                                                             (double)workload_args.min_event_size * 1.0),
-                                                        (double)workload_args.max_event_size * 1.0);
-                                            }
-                                            event_payload = payload_str.substr(0, event_size);
-                                            event_payload_size_per_rank += event_size;
-                                            writeEventTimer.resumeTimer();
-                                            ret_u = test_write_event(story_handle, event_payload);
-                                            if(workload_args.barrier)
-                                                MPI_Barrier(MPI_COMM_WORLD);
+                                                       if(workload_args.event_interval > 0)
+                                                           usleep(workload_args.event_interval);
+                                                   }
+                                               });
+                }
+                else
+                {
+                    // write event test
+                    std::string event_payload;
+                    writeEventTimer.timeBlock([&]()
+                                              {
+                                                  uint64_t event_count_per_story =
+                                                          workload_args.event_count / workload_args.story_count;
+                                                  for(uint64_t k = 0; k < event_count_per_story; k++)
+                                                  {
+                                                      if(workload_args.event_payload_file.empty())
+                                                      {
+                                                          // randomly generate events size if range is specified
+                                                          writeEventTimer.pauseTimer();
 
-                                            if(workload_args.event_interval > 0)
-                                                usleep(workload_args.event_interval);
-                                        }
-                                        else
-                                        {
-                                            // read event payload from input file line by line
-                                            std::ifstream input_file(workload_args.event_payload_file);
+                                                          uint64_t event_size;
+                                                          if(workload_args.ave_event_size ==
+                                                             workload_args.min_event_size &&
+                                                             workload_args.ave_event_size ==
+                                                             workload_args.max_event_size)
+                                                          {
+                                                              event_size = workload_args.ave_event_size;
+                                                          }
+                                                          else
+                                                          {
+                                                              event_size = (unsigned long)std::min(
+                                                                      std::max(size_dist(gen),
+                                                                              (double)workload_args.min_event_size *
+                                                                              1.0),
+                                                                      (double)workload_args.max_event_size * 1.0);
+                                                          }
+                                                          event_payload = payload_str.substr(0, event_size);
+                                                          event_payload_size_per_rank += event_size;
+                                                          writeEventTimer.resumeTimer();
+                                                          ret_u = test_write_event(story_handle, event_payload);
+                                                          if(workload_args.barrier)
+                                                              MPI_Barrier(MPI_COMM_WORLD);
 
-                                            // check if the file opened successfully
-                                            if(input_file.is_open())
-                                            {
-                                                writeEventTimer.pauseTimer();
-                                                uint64_t bigbang_timestamp = get_bigbang_timestamp(input_file);
-                                                uint64_t last_event_timestamp = bigbang_timestamp;
-                                                uint64_t event_timestamp;
-                                                struct timespec sleep_ts{};
-                                                while(std::getline(input_file, event_payload))
-                                                {
-                                                    if(event_payload.empty()) continue;
-                                                    event_timestamp = get_event_timestamp(event_payload);
-                                                    if(event_timestamp < last_event_timestamp)
-                                                    {
-                                                        LOG_INFO(
-                                                                "An Out-of-Order event is found, sleeping for 1 second ...");
-                                                        sleep_ts.tv_sec = 1;
-                                                        sleep_ts.tv_nsec = 0;
-                                                    }
-                                                    else
-                                                    {
-                                                        sleep_ts.tv_sec =
-                                                                (long)(event_timestamp - last_event_timestamp) /
-                                                                1000000000;
-                                                        sleep_ts.tv_nsec =
-                                                                (long)(event_timestamp - last_event_timestamp) %
-                                                                1000000000;
-                                                    }
-                                                    // TODO: (Kun) work around on failure when daytime changes
-                                                    if(sleep_ts.tv_sec > 3600) sleep_ts.tv_sec = 0;
-                                                    LOG_DEBUG(
-                                                            "Sleeping for {}.{} seconds to emulate interval between events ..."
-                                                            , sleep_ts.tv_sec, sleep_ts.tv_nsec);
-                                                    nanosleep(&sleep_ts, nullptr);
-                                                    last_event_timestamp = event_timestamp;
-                                                    event_payload_size_per_rank += event_payload.size();
-                                                    writeEventTimer.resumeTimer();
-                                                    ret_u = test_write_event(story_handle, event_payload);
-                                                    if(workload_args.barrier)
-                                                        MPI_Barrier(MPI_COMM_WORLD);
-                                                }
+                                                          if(workload_args.event_interval > 0)
+                                                              usleep(workload_args.event_interval);
+                                                      }
+                                                      else
+                                                      {
+                                                          // read event payload from payload file line by line
+                                                          std::ifstream input_file(workload_args.event_payload_file);
 
-                                                input_file.close();
-                                            }
-                                            else
-                                            {
-                                                std::cout << "Unable to open the file";
-                                            }
-                                        }
-                                    }
-                                });
+                                                          // check if the file opened successfully
+                                                          if(input_file.is_open())
+                                                          {
+                                                              writeEventTimer.pauseTimer();
+                                                              uint64_t bigbang_timestamp = get_bigbang_timestamp(
+                                                                      input_file);
+                                                              uint64_t last_event_timestamp = bigbang_timestamp;
+                                                              uint64_t event_timestamp;
+                                                              struct timespec sleep_ts{};
+                                                              while(std::getline(input_file, event_payload))
+                                                              {
+                                                                  if(event_payload.empty()) continue;
+                                                                  event_timestamp = get_event_timestamp(event_payload);
+                                                                  if(event_timestamp < last_event_timestamp)
+                                                                  {
+                                                                      LOG_INFO(
+                                                                              "An Out-of-Order event is found, sleeping for 1 second ...");
+                                                                      sleep_ts.tv_sec = 1;
+                                                                      sleep_ts.tv_nsec = 0;
+                                                                  }
+                                                                  else
+                                                                  {
+                                                                      sleep_ts.tv_sec = (long)(event_timestamp -
+                                                                                               last_event_timestamp) /
+                                                                                        1000000000;
+                                                                      sleep_ts.tv_nsec = (long)(event_timestamp -
+                                                                                                last_event_timestamp) %
+                                                                                         1000000000;
+                                                                  }
+                                                                  // TODO: (Kun) work around on failure when daytime changes
+                                                                  if(sleep_ts.tv_sec > 3600) sleep_ts.tv_sec = 0;
+                                                                  LOG_DEBUG(
+                                                                          "Sleeping for {}.{} seconds to emulate interval between events ..."
+                                                                          , sleep_ts.tv_sec, sleep_ts.tv_nsec);
+                                                                  nanosleep(&sleep_ts, nullptr);
+                                                                  last_event_timestamp = event_timestamp;
+                                                                  event_payload_size_per_rank += event_payload.size();
+                                                                  writeEventTimer.resumeTimer();
+                                                                  ret_u = test_write_event(story_handle, event_payload);
+                                                                  if(workload_args.barrier)
+                                                                      MPI_Barrier(MPI_COMM_WORLD);
+                                                              }
+
+                                                              input_file.close();
+                                                          }
+                                                          else
+                                                          {
+                                                              std::cout << "Unable to open the file";
+                                                          }
+                                                      }
+                                                  }
+                                              });
+                }
+
+                if(workload_args.barrier)
+                    MPI_Barrier(MPI_COMM_WORLD);
 
                 // release story test
                 ret_i = releaseStoryTimer.timeBlock(test_release_story, client, chronicle_name, story_name);
@@ -753,6 +1024,7 @@ std::vector <std::string> &command_subs)
     double local_e2e_end = MPI_Wtime();
 
     ret_i = disconnectTimer.timeBlock(&chronolog::Client::Disconnect, client);
+//    std::cout << "Return value of Disconnect: " << chronolog::to_string_client(ret_i) << std::endl;
     assert(ret_i == chronolog::CL_SUCCESS);
     if(workload_args.barrier)
         MPI_Barrier(MPI_COMM_WORLD);
@@ -771,65 +1043,76 @@ std::vector <std::string> &command_subs)
                    , MPI_COMM_WORLD);
         if(rank == 0)
         {
-            std::cout << "======================================" << std::endl;
-            std::cout << "======== Performance results: ========" << std::endl;
-            std::cout << "======================================" << std::endl;
+            std::cout << "==================================================================" << std::endl;
+            std::cout << "=================      Performance results:      =================" << std::endl;
+            std::cout << "==================================================================" << std::endl;
             global_e2e_duration_ave /= size;
-            std::cout << "Total payload written: " << total_event_payload_size << std::endl;
+            std::cout << "Total payload written: " << total_event_payload_size << " bytes" << std::endl;
+            double connect_thpt, disconnect_thpt;
+            double create_chronicle_thpt, destroy_chronicle_thpt;
+            double acquire_story_thpt, release_story_thpt, destroy_story_thpt;
+            double e2e_bandwidth, record_event_bw, record_event_thpt, replay_story_bw, replay_story_thpt;
+            e2e_bandwidth = record_event_bw = record_event_thpt = replay_story_bw = replay_story_thpt = 0.0;
             if(workload_args.barrier)
             {
-                std::cout << "Connect throughput: " << (double)size / connectTimer.getDuration() << " op/s"
-                          << std::endl;
-                std::cout << "CreateChronicle throughput: "
-                          << (double)workload_args.chronicle_count * size / createChronicleTimer.getDuration()
-                          << " op/s" << std::endl;
-                std::cout << "AcquireStory throughput: "
-                          << (double)workload_args.story_count * size / acquireStoryTimer.getDuration() << " op/s"
-                          << std::endl;
-                std::cout << "ReleaseStory throughput: "
-                          << (double)workload_args.story_count * size / releaseStoryTimer.getDuration() << " op/s"
-                          << std::endl;
-                std::cout << "DestroyStory throughput: "
-                          << (double)workload_args.story_count * size / destroyStoryTimer.getDuration() << " op/s"
-                          << std::endl;
-                std::cout << "DestroyChronicle throughput: "
-                          << (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDuration()
-                          << " op/s" << std::endl;
-                std::cout << "Disconnect throughput: " << (double)size / disconnectTimer.getDuration() << " op/s"
-                          << std::endl;
-                std::cout << "End-to-end bandwidth: " << (double)total_event_payload_size / global_e2e_duration / 1e6
-                          << " MB/s" << std::endl;
-                std::cout << "Data-access bandwidth: "
-                          << (double)total_event_payload_size / writeEventTimer.getDuration() / 1e6 << " "
-                                                                                                       "MB/s"
-                          << std::endl;
+                connect_thpt = (double)size / connectTimer.getDuration();
+                create_chronicle_thpt = (double)workload_args.chronicle_count * size / createChronicleTimer.getDuration();
+                acquire_story_thpt = (double)workload_args.story_count * size / acquireStoryTimer.getDuration();
+                release_story_thpt = (double)workload_args.story_count * size / releaseStoryTimer.getDuration();
+                destroy_story_thpt = (double)workload_args.story_count * size / destroyStoryTimer.getDuration();
+                destroy_chronicle_thpt = (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDuration();
+                disconnect_thpt = (double)size / disconnectTimer.getDuration();
+                e2e_bandwidth = (double)total_event_payload_size / global_e2e_duration / 1e6;
+                if(workload_args.read)
+                {
+                    replay_story_bw = (double)total_event_payload_size / replayStoryTimer.getDuration() / 1e6;
+                    replay_story_thpt = (double)workload_args.event_count * size / replayStoryTimer.getDuration() / 1e6;
+                }
+                else if(workload_args.read)
+                {
+                    record_event_bw = (double)total_event_payload_size / writeEventTimer.getDuration() / 1e6;
+                    record_event_thpt = (double)workload_args.event_count * size / writeEventTimer.getDuration() / 1e6;
+                }
             }
             else
             {
-                std::cout << "Connect throughput: " << (double)size / connectTimer.getDurationAve() << " op/s"
-                          << std::endl;
-                std::cout << "CreateChronicle throughput: "
-                          << (double)workload_args.chronicle_count * size / createChronicleTimer.getDurationAve()
-                          << " op/s" << std::endl;
-                std::cout << "AcquireStory throughput: "
-                          << (double)workload_args.story_count * size / acquireStoryTimer.getDurationAve() << " op/s"
-                          << std::endl;
-                std::cout << "ReleaseStory throughput: "
-                          << (double)workload_args.story_count * size / releaseStoryTimer.getDurationAve() << " op/s"
-                          << std::endl;
-                std::cout << "DestroyStory throughput: "
-                          << (double)workload_args.story_count * size / destroyStoryTimer.getDurationAve() << " op/s"
-                          << std::endl;
-                std::cout << "DestroyChronicle throughput: "
-                          << (double)workload_args.chronicle_count / destroyChronicleTimer.getDurationAve() << " op/s"
-                          << std::endl;
-                std::cout << "Disconnect throughput: " << (double)size / disconnectTimer.getDurationAve() << " op/s"
-                          << std::endl;
-                std::cout << "End-to-end bandwidth: "
-                          << (double)total_event_payload_size / global_e2e_duration_ave / 1e6 << " MB/s" << std::endl;
-                std::cout << "Data-access bandwidth: "
-                          << (double)total_event_payload_size / writeEventTimer.getDurationAve() / 1e6 << " MB/s"
-                          << std::endl;
+                connect_thpt = (double)size / connectTimer.getDurationAve();
+                create_chronicle_thpt = (double)workload_args.chronicle_count * size / createChronicleTimer.getDurationAve();
+                acquire_story_thpt = (double)workload_args.story_count * size / acquireStoryTimer.getDurationAve();
+                release_story_thpt = (double)workload_args.story_count * size / releaseStoryTimer.getDurationAve();
+                destroy_story_thpt = (double)workload_args.story_count * size / destroyStoryTimer.getDurationAve();
+                destroy_chronicle_thpt = (double)workload_args.chronicle_count * size / destroyChronicleTimer.getDurationAve();
+                disconnect_thpt = (double)size / disconnectTimer.getDurationAve();
+                e2e_bandwidth = (double)total_event_payload_size / global_e2e_duration / 1e6;
+                if(workload_args.read)
+                {
+                    replay_story_bw = (double)total_event_payload_size / replayStoryTimer.getDurationAve() / 1e6;
+                    replay_story_thpt = (double)workload_args.event_count * size / replayStoryTimer.getDurationAve() / 1e6;
+
+                }
+                else
+                {
+                    record_event_bw = (double)total_event_payload_size / writeEventTimer.getDurationAve() / 1e6;
+                    record_event_thpt = (double)workload_args.event_count * size / writeEventTimer.getDurationAve() / 1e6;
+                }
+            }
+            std::cout << "Connect throughput: " << connect_thpt << " connections/s" << std::endl;
+            std::cout << "CreateChronicle throughput: " << create_chronicle_thpt << " creations/s" << std::endl;
+            std::cout << "AcquireStory throughput: " << acquire_story_thpt << " acquisitions/s" << std::endl;
+            std::cout << "ReleaseStory throughput: " << release_story_thpt << " releases/s" << std::endl;
+            std::cout << "DestroyStory throughput: " << destroy_story_thpt << " destructions/s" << std::endl;
+            std::cout << "DestroyChronicle throughput: " << destroy_chronicle_thpt << " destructions/s" << std::endl;
+            std::cout << "Disconnect throughput: " << disconnect_thpt << " disconnections/s" << std::endl;
+            std::cout << "End-to-end (incl. metadata time) bandwidth: " << e2e_bandwidth << " MB/s" << std::endl;
+            if(workload_args.read)
+            {
+                std::cout << "Replay-story (incl. metadata time) bandwidth: " << replay_story_bw << " MB/s" << std::endl;
+                std::cout << "Replay-story (incl. metadata time) throughput: " << replay_story_thpt << " events/s" << std::endl;
+            }
+            else
+            {
+                std::cout << "Record-event (incl. metadata time) bandwidth: " << record_event_bw << " MB/s" << std::endl;
+                std::cout << "Record-event (incl. metadata time) throughput: " << record_event_thpt << " events/s" << std::endl;
             }
         }
     }


### PR DESCRIPTION
Changes in this PR:

- Add read mode to `client_admin` (command-line args are incompatible with previous versions)
- Improve `client_admin` with easier-to-understand output
- Improve `client_admin` with better interaction guidance

---
Linked issues (added retroactively):
Closes #343

