### PR TITLE
Switch from mpssh to pssh for improved compatibility

### DIFF
--- a/CI/docker/local.dockerfile
+++ b/CI/docker/local.dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update \
     libjson-c-dev libboost-dev libcereal-dev \
     git vim fuse sudo curl wget \
     libfuse-dev libssl-dev \
-    python3-dev bzip2 xz-utils jq net-tools lsof htop pssh bind9-dnsutils
+    python3-dev bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils
 
 RUN apt-get -y install --no-install-recommends \
-    openssh-server \
+    openssh-server openssh-client \
   && printf '%s\n' \
     'PermitRootLogin yes' \
     'PasswordAuthentication yes' \
@@ -68,15 +68,6 @@ RUN cd \
  && cd ../deploy \
  # && ./local_single_user_deploy.sh -b --install-dir ~/chronolog_install/Release \
  && ./local_single_user_deploy.sh -i --work-dir ~/chronolog_install/Release
-
-# Install mpssh for distributed deployment
-RUN cd \
- && git clone https://github.com/ndenev/mpssh.git \
- && cd mpssh \
- && make -j \
- && sudo make -j install \
- && cd \
- && rm -rf mpssh
 
 # Source Spack on each shell
 RUN cd \

--- a/CI/docker/local.dockerfile
+++ b/CI/docker/local.dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update \
     libjson-c-dev libboost-dev libcereal-dev \
     git vim fuse sudo curl wget \
     libfuse-dev libssl-dev \
-    python3-dev bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils
+    python3 python3-dev python3-pip \
+    bzip2 xz-utils jq net-tools lsof htop pssh procps bind9-dnsutils
 
 RUN apt-get -y install --no-install-recommends \
     openssh-server openssh-client \
@@ -32,7 +33,8 @@ RUN apt-get -y install --no-install-recommends \
   && printf '%s\n' \
     'Host *' \
     '    StrictHostKeyChecking no' \
-    > /etc/ssh/ssh_config.d/ignore-host-key.conf
+    > /etc/ssh/ssh_config.d/ignore-host-key.conf \
+  && pip3 install pssh
 
 RUN id $UID && userdel $(id -un $UID) || : \
  && useradd -m -u $UID -s /bin/bash $USERNAME \

--- a/deploy/single_user_deploy.sh
+++ b/deploy/single_user_deploy.sh
@@ -140,7 +140,7 @@ usage() {
 }
 
 check_dependencies() {
-    local dependencies=("jq" "mpssh" "ssh" "ldd" "nohup" "pkill" "readlink" "realpath")
+    local dependencies=("jq" "pssh" "ssh" "ldd" "nohup" "pkill" "readlink" "realpath")
 
     echo -e "${DEBUG}Checking required dependencies...${NC}"
     for dep in "${dependencies[@]}"; do
@@ -590,7 +590,7 @@ parallel_remote_launch_processes() {
     fi
 
     bin_path=${bin_dir}/${bin_filename}
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" mpssh -s -f ${hosts_file} "cd ${bin_dir}; LD_LIBRARY_PATH=${lib_dir} nohup ${bin_path} ${args} > ${MONITOR_DIR}/${bin_filename}${hostname_suffix}.launch.log 2>&1 &" | grep "${simple_output_grep_keyword}" 2>&1
+    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "cd ${bin_dir}; LD_LIBRARY_PATH=${lib_dir} nohup ${bin_path} ${args} > ${MONITOR_DIR}/${bin_filename}${hostname_suffix}.launch.log 2>&1 &" | grep "${simple_output_grep_keyword}" 2>&1
 }
 
 parallel_remote_stop_processes() {
@@ -598,7 +598,7 @@ parallel_remote_stop_processes() {
     local bin_filename=$2
 
     local timer=0
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" mpssh -s -f ${hosts_file} "pkill --signal 15 -ef ${bin_filename}" | grep -e "->" | grep -v ssh 2>&1
+    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "pkill --signal 15 -ef ${bin_filename}" 2>/dev/null
     while [[ -n $(parallel_remote_check_processes ${hosts_file} ${bin_filename}) ]]; do
         echo -e "${DEBUG}Some processes are still running, waiting for 10 seconds ...${NC}"
         sleep 10
@@ -615,14 +615,14 @@ parallel_remote_kill_processes() {
     local hosts_file=$1
     local bin_filename=$2
 
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" mpssh -s -f ${hosts_file} "pkill --signal 9 -ef ${bin_filename}" | grep -e "->" | grep -v ssh 2>&1
+    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "pkill --signal 9 -ef ${bin_filename}" 2>/dev/null
 }
 
 parallel_remote_check_processes() {
     local hosts_file=$1
     local bin_filename=$2
 
-    LD_LIBRARY_PATH="${SYS_LIB_DIR}" mpssh -s -f ${hosts_file} "pgrep -fla ${bin_filename}" | grep -e "->" | grep -v ssh 2>&1
+    LD_LIBRARY_PATH="${SYS_LIB_DIR}" pssh -h ${hosts_file} -i "pgrep -fla ${bin_filename}" 2>/dev/null | grep -vE '^\[' | sed '/^$/d'
 }
 
 parallel_remote_check_all() {


### PR DESCRIPTION
Replaced mpssh with pssh to fix arm64 build issues in GitHub Actions while preserving existing functionality.

---
Linked issues (added retroactively):
Closes #395
