### PR TITLE
Add Clang Format Check GitHub Action

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,201 @@
+name: Clang Format Check
+
+on:
+  pull_request:
+    branches: [ develop, main ]
+    paths:
+      - '**/*.cpp'
+      - '**/*.h'
+      - '**/*.hpp'
+      - '**/*.cc'
+      - '**/*.cxx'
+      - '**/*.c'
+      - 'CodeStyleFiles/ChronoLog.clang-format'
+
+jobs:
+  clang-format-check:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full history for proper diff
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: Check clang-format version
+        run: clang-format --version
+
+      - name: Find C/C++ files
+        id: find-files
+        run: |
+          # Find all C/C++ files that are staged or modified in the PR
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Get the list of changed files in the PR
+            git diff --name-only --diff-filter=AM origin/${{ github.base_ref }}...HEAD | \
+              grep -E '\.(cpp|h|hpp|cc|cxx|c)$' > changed_files.txt || true
+          else
+            # For other events, check all C/C++ files
+            find . -name "*.cpp" -o -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cxx" -o -name "*.c" | \
+              grep -v "./build/" | grep -v "./.git/" > changed_files.txt
+          fi
+          
+          echo "Files to check:"
+          cat changed_files.txt || echo "No C/C++ files found"
+          
+          # Count files
+          file_count=$(wc -l < changed_files.txt 2>/dev/null || echo "0")
+          echo "file_count=$file_count" >> $GITHUB_OUTPUT
+
+      - name: Check formatting
+        id: format-check
+        run: |
+          if [ ! -s changed_files.txt ]; then
+            echo "No C/C++ files to check"
+            echo "has_format_issues=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Checking formatting for $(wc -l < changed_files.txt) files..."
+          
+          # Create a temporary directory for formatted files
+          mkdir -p /tmp/formatted
+          
+          # Check each file and collect issues
+          format_issues=()
+          while IFS= read -r file; do
+            if [ -f "$file" ]; then
+              echo "Checking: $file"
+              
+              # Create formatted version
+              clang-format -style=file:CodeStyleFiles/ChronoLog.clang-format "$file" > "/tmp/formatted/$(basename "$file")"
+              
+              # Compare with original
+              if ! diff -q "$file" "/tmp/formatted/$(basename "$file")" > /dev/null; then
+                echo "❌ Formatting issues found in: $file"
+                format_issues+=("$file")
+              else
+                echo "✅ $file is properly formatted"
+              fi
+            fi
+          done < changed_files.txt
+          
+          if [ ${#format_issues[@]} -eq 0 ]; then
+            echo "✅ All files are properly formatted!"
+            echo "has_format_issues=false" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Found formatting issues in ${#format_issues[@]} files"
+            echo "has_format_issues=true" >> $GITHUB_OUTPUT
+            printf '%s\n' "${format_issues[@]}" > format_issues.txt
+          fi
+
+      - name: Generate format patches
+        if: steps.format-check.outputs.has_format_issues == 'true'
+        run: |
+          echo "Generating format patches..."
+          
+          # Create patches directory
+          mkdir -p format_patches
+          
+          # Generate patches for each file with issues
+          while IFS= read -r file; do
+            if [ -f "$file" ]; then
+              echo "Generating patch for: $file"
+              
+              # Create formatted version
+              clang-format -style=file:CodeStyleFiles/ChronoLog.clang-format "$file" > "/tmp/formatted/$(basename "$file")"
+              
+              # Generate unified diff patch
+              patch_file="format_patches/$(echo "$file" | sed 's|/|_|g').patch"
+              diff -u "$file" "/tmp/formatted/$(basename "$file")" > "$patch_file" || true
+              
+              echo "Patch created: $patch_file"
+            fi
+          done < format_issues.txt
+          
+          # Create a combined patch file
+          if [ -d "format_patches" ] && [ "$(ls -A format_patches)" ]; then
+            echo "Creating combined patch file..."
+            cat format_patches/*.patch > format_fixes.patch
+            echo "Combined patch created: format_fixes.patch"
+          fi
+
+      - name: Upload format patches as artifacts
+        if: steps.format-check.outputs.has_format_issues == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-format-patches
+          path: |
+            format_patches/
+            format_fixes.patch
+          retention-days: 7
+
+      - name: Comment on PR with format issues
+        if: steps.format-check.outputs.has_format_issues == 'true' && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            
+            // Read the list of files with issues
+            let issueFiles = [];
+            try {
+              const content = fs.readFileSync('format_issues.txt', 'utf8');
+              issueFiles = content.trim().split('\n').filter(line => line.length > 0);
+            } catch (error) {
+              console.log('Could not read format_issues.txt');
+            }
+            
+            // Create comment body
+            let commentBody = `## ❌ Clang Format Check Failed\n\n`;
+            commentBody += `Found formatting issues in **${issueFiles.length}** file(s):\n\n`;
+            
+            issueFiles.forEach(file => {
+              commentBody += `- \`${file}\`\n`;
+            });
+            
+            commentBody += `\n### How to fix:\n\n`;
+            commentBody += `1. **Download the patches** from the "clang-format-patches" artifact above\n`;
+            commentBody += `2. **Apply the patches** to your local repository:\n`;
+            commentBody += `   \`\`\`bash\n`;
+            commentBody += `   # Download and extract the artifact\n`;
+            commentBody += `   # Then apply the combined patch:\n`;
+            commentBody += `   git apply format_fixes.patch\n`;
+            commentBody += `   \`\`\`\n\n`;
+            commentBody += `3. **Or format manually** using clang-format:\n`;
+            commentBody += `   \`\`\`bash\n`;
+            issueFiles.forEach(file => {
+              commentBody += `   clang-format -i -style=file:CodeStyleFiles/ChronoLog.clang-format ${file}\n`;
+            });
+            commentBody += `   \`\`\`\n\n`;
+            commentBody += `4. **Commit and push** the formatting changes\n\n`;
+            commentBody += `### Format patches are available as artifacts above ⬆️\n\n`;
+            commentBody += `---\n`;
+            commentBody += `*This check ensures consistent code style across the project.*`;
+            
+            // Post comment
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentBody
+            });
+
+      - name: Fail if format issues found
+        if: steps.format-check.outputs.has_format_issues == 'true'
+        run: |
+          echo "❌ Clang format check failed!"
+          echo "Please fix the formatting issues and push your changes."
+          echo "Format patches are available in the artifacts."
+          exit 1
+
+      - name: Success message
+        if: steps.format-check.outputs.has_format_issues == 'false'
+        run: |
+          echo "✅ All C/C++ files are properly formatted!"

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -73,10 +73,10 @@ jobs:
               echo "Checking: $file"
               
               # Create formatted version
-              clang-format -style=file:CodeStyleFiles/ChronoLog.clang-format "$file" > "/tmp/formatted/$(basename "$file")"
+              clang-format -style=file:CodeStyleFiles/ChronoLog.clang-format "$file" > "/tmp/formatted/$(echo "$file" | sed 's|/|_|g')"
               
               # Compare with original
-              if ! diff -q "$file" "/tmp/formatted/$(basename "$file")" > /dev/null; then
+              if ! diff -q "$file" "/tmp/formatted/$(echo "$file" | sed 's|/|_|g')" > /dev/null; then
                 echo "❌ Formatting issues found in: $file"
                 format_issues+=("$file")
               else
@@ -108,11 +108,11 @@ jobs:
               echo "Generating patch for: $file"
               
               # Create formatted version
-              clang-format -style=file:CodeStyleFiles/ChronoLog.clang-format "$file" > "/tmp/formatted/$(basename "$file")"
+              clang-format -style=file:CodeStyleFiles/ChronoLog.clang-format "$file" > "/tmp/formatted/$(echo "$file" | sed 's|/|_|g')"
               
               # Generate unified diff patch
               patch_file="format_patches/$(echo "$file" | sed 's|/|_|g').patch"
-              diff -u "$file" "/tmp/formatted/$(basename "$file")" > "$patch_file" || true
+              diff -u "$file" "/tmp/formatted/$(echo "$file" | sed 's|/|_|g')" > "$patch_file" || true
               
               echo "Patch created: $patch_file"
             fi


### PR DESCRIPTION
This commit introduces a new GitHub Action workflow for checking C/C++ code formatting using clang-format. The action runs on pull requests targeting the develop and main branches, checking for formatting issues in specified file types. It installs clang-format, identifies modified files, and reports any formatting discrepancies. If issues are found, it generates patches and comments on the pull request with instructions for resolution.

---
Linked issues (added retroactively):
Closes #371