### PR TITLE
Add CPU devcontainer and fix CMake portability bugs

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Configures and builds ChronoLog in Release mode.
+# Called by post-create.sh on first container creation; also safe to run manually.
+set -euo pipefail
+
+BUILD_DIR="${HOME}/chronolog-build/Release"
+INSTALL_DIR="${HOME}/chronolog-install"
+REPO_ROOT="$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")"
+
+echo "==> Configuring ChronoLog (Release)..."
+cmake \
+    -S "${REPO_ROOT}" \
+    -B "${BUILD_DIR}" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
+    -DCHRONOLOG_USE_ADDRESS_SANITIZER=OFF
+
+echo "==> Building ChronoLog..."
+cmake --build "${BUILD_DIR}" --parallel "$(nproc)"
+
+echo "==> Build successful. Binaries in: ${BUILD_DIR}"

--- a/.devcontainer/cpu/Dockerfile
+++ b/.devcontainer/cpu/Dockerfile
@@ -1,0 +1,103 @@
+ARG BASE_IMAGE=ubuntu:24.04
+FROM ${BASE_IMAGE}
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# ── System packages ───────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    # Build toolchain
+    gcc g++ gdb make ninja-build \
+    cmake \
+    autoconf automake libtool pkg-config \
+    # Source / VCS
+    git curl wget \
+    # ChronoLog direct apt-installable deps
+    libboost-all-dev \
+    libhdf5-dev \
+    libjson-c-dev \
+    libssl-dev \
+    libfuse-dev \
+    libfabric-dev \
+    libspdlog-dev \
+    libcereal-dev \
+    python3-dev python3-pip \
+    pybind11-dev \
+    libgtest-dev \
+    libmpich-dev mpich \
+    libcurl4-openssl-dev \
+    # Dev convenience
+    sudo vim less procps openssh-server \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── Argobots 1.2 (no Ubuntu package) ─────────────────────────────────────────
+RUN git clone --depth 1 --branch v1.2 \
+        https://github.com/pmodels/argobots.git /tmp/argobots \
+ && cd /tmp/argobots \
+ && ./autogen.sh \
+ && ./configure --prefix=/usr/local \
+ && make -j"$(nproc)" \
+ && make install \
+ && rm -rf /tmp/argobots
+
+# ── Mercury 2.2.0 ─────────────────────────────────────────────────────────────
+RUN git clone --depth 1 --branch v2.2.0 \
+        https://github.com/mercury-hpc/mercury.git /tmp/mercury \
+ && cmake -S /tmp/mercury -B /tmp/mercury-build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+          -DBUILD_SHARED_LIBS=ON \
+          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+          -DNA_USE_OFI=ON \
+          -DNA_USE_SM=ON \
+          -DMERCURY_USE_BOOST_PP=ON \
+ && cmake --build /tmp/mercury-build --parallel "$(nproc)" \
+ && cmake --install /tmp/mercury-build \
+ && rm -rf /tmp/mercury /tmp/mercury-build
+
+# ── Mochi-Margo 0.13.1 ────────────────────────────────────────────────────────
+RUN git clone --depth 1 --branch v0.13.1 \
+        https://github.com/mochi-hpc/mochi-margo.git /tmp/margo \
+ && cd /tmp/margo \
+ && autoreconf -i \
+ && ./configure --prefix=/usr/local \
+ && make -j"$(nproc)" \
+ && make install \
+ && rm -rf /tmp/margo
+
+# ── Mochi-Thallium 0.10.1 ────────────────────────────────────────────────────
+RUN git clone --depth 1 --branch v0.10.1 \
+        https://github.com/mochi-hpc/mochi-thallium.git /tmp/thallium \
+ && cmake -S /tmp/thallium -B /tmp/thallium-build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=/usr/local \
+ && cmake --build /tmp/thallium-build --parallel "$(nproc)" \
+ && cmake --install /tmp/thallium-build \
+ && rm -rf /tmp/thallium /tmp/thallium-build
+
+# Refresh the dynamic linker cache
+RUN ldconfig
+
+# ── Dev user ──────────────────────────────────────────────────────────────────
+# Remap grc-iit user UID/GID to match the host user to avoid bind-mount
+# permission issues.  Override at build time with --build-arg HOST_UID=...
+ARG HOST_UID=1000
+ARG HOST_GID=1000
+
+# Ubuntu 24.04 ships a default "ubuntu" user at UID 1000 which blocks UID
+# remapping.  Move it out of the way first.
+RUN if id ubuntu >/dev/null 2>&1; then \
+      usermod -u 59999 ubuntu && groupmod -g 59999 ubuntu; \
+    fi \
+ && groupadd -g "${HOST_GID}" grc-iit 2>/dev/null || true \
+ && useradd -m -u "${HOST_UID}" -g "${HOST_GID}" -s /bin/bash grc-iit \
+ && echo "grc-iit ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/grc-iit
+
+# Install Claude Code
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+USER grc-iit
+WORKDIR /workspace
+CMD ["/bin/bash"]

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -1,0 +1,55 @@
+{
+  "name": "ChronoLog (CPU)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "../..",
+    "args": {
+      "HOST_UID": "${localEnv:HOST_UID:1000}",
+      "HOST_GID": "${localEnv:HOST_GID:1000}"
+    },
+    "options": [
+      "--tag=chronolog/devcontainer-cpu:latest"
+    ]
+  },
+  "workspaceFolder": "/workspace",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=cached",
+  "containerEnv": {
+    "CHRONOLOG_ROOT": "${localWorkspaceFolder}",
+    "LD_LIBRARY_PATH": "/usr/local/lib:/usr/lib/x86_64-linux-gnu"
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/tmp/host-ssh,type=bind,readonly",
+    "source=${localEnv:HOME}/.claude,target=/tmp/host-claude,type=bind,readonly",
+    "source=${localEnv:HOME}/.claude.json,target=/tmp/host-claude.json,type=bind,readonly",
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
+  "runArgs": [
+    "--privileged"
+  ],
+  "updateRemoteUserUID": true,
+  "initializeCommand": "bash -c 'mkdir -p ~/.ssh ~/.claude && chmod 700 ~/.ssh && touch ~/.claude.json'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "twxs.cmake",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "KylinIdeTeam.cppdebug",
+        "ms-azuretools.vscode-docker",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy"
+      ],
+      "settings": {
+        "cmake.configureOnOpen": false,
+        "cmake.buildDirectory": "${workspaceFolder}/../chronolog-build/${buildType}",
+        "cmake.installPrefix": "${workspaceFolder}/../chronolog-install"
+      }
+    }
+  },
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "postStartCommand": ".devcontainer/post-start.sh",
+  "remoteUser": "grc-iit"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Devcontainer post-create setup — runs once when the container is first created.
+set -e
+
+DEVUSER="grc-iit"
+HOME_DIR="/home/${DEVUSER}"
+
+# Mark workspace as safe for git
+git config --global --add safe.directory /workspace
+
+# Copy host SSH keys into container
+sudo rm -rf "${HOME_DIR}/.ssh"
+if [ -d /tmp/host-ssh ]; then
+    sudo cp -r /tmp/host-ssh "${HOME_DIR}/.ssh"
+    sudo chown -R "${DEVUSER}:${DEVUSER}" "${HOME_DIR}/.ssh"
+    chmod 700 "${HOME_DIR}/.ssh"
+    chmod 600 "${HOME_DIR}/.ssh"/* 2>/dev/null || true
+    chmod 644 "${HOME_DIR}/.ssh"/*.pub 2>/dev/null || true
+fi
+
+# Copy host Claude config into container
+if [ -d /tmp/host-claude ] && [ "$(ls -A /tmp/host-claude)" ]; then
+    sudo cp -r /tmp/host-claude "${HOME_DIR}/.claude"
+    sudo chown -R "${DEVUSER}:${DEVUSER}" "${HOME_DIR}/.claude"
+fi
+if [ -f /tmp/host-claude.json ] && [ -s /tmp/host-claude.json ]; then
+    sudo cp /tmp/host-claude.json "${HOME_DIR}/.claude.json"
+    sudo chown "${DEVUSER}:${DEVUSER}" "${HOME_DIR}/.claude.json"
+fi
+
+# Fix docker socket permissions
+"$(dirname "$0")/post-start.sh"
+
+# Start SSH service
+sudo service ssh start || true
+
+# Build ChronoLog
+"$(dirname "$0")/build.sh"

--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Devcontainer post-start setup — runs every time the container starts.
+# Opens the Docker socket so the dev user can use Docker regardless of host GID.
+
+if [ -S /var/run/docker.sock ]; then
+    sudo chmod 666 /var/run/docker.sock
+fi

--- a/ChronoGrapher/CMakeLists.txt
+++ b/ChronoGrapher/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 find_package(Thallium REQUIRED)
+find_package(spdlog REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C CXX)
 
 #------------------------------------------------------------------------------
@@ -11,6 +12,7 @@ add_executable(chrono_grapher)
 target_include_directories(chrono_grapher PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/chrono_common/include
+    ${HDF5_INCLUDE_DIRS}
 )
 
 target_sources(chrono_grapher PRIVATE
@@ -25,6 +27,7 @@ target_link_libraries(chrono_grapher
         chrono_common
         chronolog_client
         thallium
+        spdlog::spdlog
         ${HDF5_LIBRARIES}
 )
 

--- a/ChronoKeeper/CMakeLists.txt
+++ b/ChronoKeeper/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 find_package(Thallium REQUIRED)
+find_package(spdlog REQUIRED)
 
 #------------------------------------------------------------------------------
 # ChronoKeeper Executable
@@ -24,6 +25,7 @@ target_link_libraries(chrono_keeper
         chrono_common
         chronolog_client
         thallium
+        spdlog::spdlog
 )
 
 set_target_properties(chrono_keeper PROPERTIES

--- a/ChronoPlayer/CMakeLists.txt
+++ b/ChronoPlayer/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 find_package(Thallium REQUIRED)
+find_package(spdlog REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C CXX)
 
 #------------------------------------------------------------------------------
@@ -11,6 +12,7 @@ add_executable(chrono_player)
 target_include_directories(chrono_player PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/chrono_common/include
+    ${HDF5_INCLUDE_DIRS}
 )
 
 target_sources(chrono_player PRIVATE
@@ -28,6 +30,7 @@ target_link_libraries(chrono_player
         chrono_common
         chronolog_client
         thallium
+        spdlog::spdlog
         ${HDF5_LIBRARIES}
 )
 

--- a/ChronoVisor/CMakeLists.txt
+++ b/ChronoVisor/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 find_package(Thallium REQUIRED)
+find_package(spdlog REQUIRED)
 
 set(CMAKE_FIND_LIBRARY_TYPE STATIC)
 
@@ -29,6 +30,7 @@ target_link_libraries(chronovisor_server
         chrono_common
         chronolog_client
         thallium
+        spdlog::spdlog
 )
 
 set_target_properties(chronovisor_server PROPERTIES

--- a/Client/examples/cpp/CMakeLists.txt
+++ b/Client/examples/cpp/CMakeLists.txt
@@ -87,9 +87,9 @@ target_link_libraries(client_lib_distributed_telemetry_writer_example
     PRIVATE
         chronolog_client
         thallium
+        MPI::MPI_CXX
         pthread
         rt
-        ${MPI_CXX_LIBRARIES}
 )
 
 set_target_properties(client_lib_distributed_telemetry_writer_example PROPERTIES

--- a/chrono_common/CMakeLists.txt
+++ b/chrono_common/CMakeLists.txt
@@ -24,6 +24,7 @@ target_include_directories(chrono_common
         $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/Client/cpp/include>
     PRIVATE
         ${CMAKE_SOURCE_DIR}/Client/cpp/include
+        ${HDF5_INCLUDE_DIRS}
 )
 
 target_link_libraries(chrono_common


### PR DESCRIPTION
## Summary

- Adds a VS Code devcontainer (`.devcontainer/cpu/`) for local development **without Spack**, building the mochi stack (argobots 1.2, mercury 2.2.0, mochi-margo 0.13.1, mochi-thallium 0.10.1) from source using standard apt packages for all other deps
- Follows the `iowarp/core` devcontainer conventions: `cpu/` variant subdirectory, `HOST_UID`/`HOST_GID` remapping, shared `post-create.sh`/`post-start.sh` lifecycle scripts, SSH key + Claude config mounts, Docker socket, and Claude Code pre-installed
- Fixes three CMake portability bugs masked by Spack's global prefix path

## CMake fixes

| File | Bug | Fix |
|---|---|---|
| `chrono_common`, `ChronoPlayer`, `ChronoGrapher` CMakeLists | Missing `${HDF5_INCLUDE_DIRS}` — `H5Cpp.h` not found outside Spack prefix | Added to `target_include_directories` |
| `ChronoVisor`, `ChronoKeeper`, `ChronoGrapher`, `ChronoPlayer` CMakeLists | `chrono_monitor.cpp` compiled directly without `spdlog::spdlog` link — `fmt` symbols unresolved when using system libfmt | Added `find_package(spdlog)` + `spdlog::spdlog` |
| `Client/examples/cpp` CMakeLists | `${MPI_CXX_LIBRARIES}` linked without `${MPI_CXX_INCLUDE_DIRS}` | Replaced with `MPI::MPI_CXX` imported target |

## Test plan

- [ ] Open repo in VS Code → **Reopen in Container** → selects `cpu` variant
- [ ] `post-create.sh` runs, ChronoLog builds to 100% inside the container
- [ ] Docker image builds cleanly: `docker build --build-arg HOST_UID=$(id -u) --build-arg HOST_GID=$(id -g) -f .devcontainer/cpu/Dockerfile .`
- [ ] Verify no `InvalidDefaultArgInFrom` linter warning (fixed by `ARG BASE_IMAGE=ubuntu:24.04` before `FROM`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)