### PR TITLE
Add protocol_version handshake to Connect RPC

### DIFF
--- a/ChronoVisor/include/ClientPortalService.h
+++ b/ChronoVisor/include/ClientPortalService.h
@@ -9,6 +9,7 @@
 #include <thallium/serialization/stl/vector.hpp>
 #include <thallium/serialization/stl/unordered_map.hpp>
 
+#include <chronolog_client.h>
 #include <chronolog_types.h>
 #include <KeeperIdCard.h>
 #include <ConnectResponseMsg.h>
@@ -37,8 +38,21 @@ public:
         get_engine().pop_finalize_callback(this);
     }
 
-    void Connect(tl::request const& request, uint32_t client_account, uint32_t client_host_ip, uint32_t client_pid)
+    void Connect(tl::request const& request,
+                 uint32_t client_account,
+                 uint32_t client_host_ip,
+                 uint32_t client_pid,
+                 uint32_t client_protocol_version)
     {
+        if(client_protocol_version != chronolog::CLIENT_PROTOCOL_VERSION)
+        {
+            LOG_ERROR("[ClientPortalService] Connect rejected: client protocol version {} does not match server {}",
+                      client_protocol_version,
+                      chronolog::CLIENT_PROTOCOL_VERSION);
+            request.respond(ConnectResponseMsg(chronolog::CL_ERR_PROTOCOL_VERSION_MISMATCH, ClientId{0}));
+            return;
+        }
+
         ClientId client_id;
         uint64_t clock_offset;
         int return_code =

--- a/Client/cpp/include/chronolog_client.h
+++ b/Client/cpp/include/chronolog_client.h
@@ -19,6 +19,12 @@ typedef uint64_t ClientId;
 typedef uint64_t chrono_time;
 typedef uint32_t chrono_index;
 
+// Wire-protocol version exchanged on Connect. Bump this whenever the wire
+// format between the client and any ChronoLog server component changes in
+// an incompatible way; the Visor returns CL_ERR_PROTOCOL_VERSION_MISMATCH
+// if a connecting client's version doesn't match the server's expectation.
+static constexpr uint32_t CLIENT_PROTOCOL_VERSION = 1;
+
 class Event
 {
 public:

--- a/Client/cpp/include/client_errcode.h
+++ b/Client/cpp/include/client_errcode.h
@@ -7,19 +7,20 @@ namespace chronolog
 // A simple enum for client-only errors:
 enum ClientErrorCode
 {
-    CL_SUCCESS = 0,               // Success
-    CL_ERR_UNKNOWN = -1,          // Generic error
-    CL_ERR_INVALID_ARG = -2,      // Invalid input
-    CL_ERR_NOT_EXIST = -3,        // Missing Chronicle, Story, or property
-    CL_ERR_ACQUIRED = -4,         // Already acquired; cannot be destroyed; unsafe to disconnect
-    CL_ERR_NOT_ACQUIRED = -5,     // Not acquired; cannot be released
-    CL_ERR_CHRONICLE_EXISTS = -6, // Chronicle already exists
-    CL_ERR_NO_KEEPERS = -7,       // No ChronoKeepers available
-    CL_ERR_NO_CONNECTION = -8,    // No connection to ChronoVisor
-    CL_ERR_NOT_AUTHORIZED = -9,   // Unauthorized operation
-    CL_ERR_NO_PLAYERS = -10,      // No ChronoPlayers available
-    CL_ERR_NOT_READER_MODE = -11, // Client is running in WRITER_MODE
-    CL_ERR_QUERY_TIMED_OUT = -12  // Replay query timed out
+    CL_SUCCESS = 0,                        // Success
+    CL_ERR_UNKNOWN = -1,                   // Generic error
+    CL_ERR_INVALID_ARG = -2,               // Invalid input
+    CL_ERR_NOT_EXIST = -3,                 // Missing Chronicle, Story, or property
+    CL_ERR_ACQUIRED = -4,                  // Already acquired; cannot be destroyed; unsafe to disconnect
+    CL_ERR_NOT_ACQUIRED = -5,              // Not acquired; cannot be released
+    CL_ERR_CHRONICLE_EXISTS = -6,          // Chronicle already exists
+    CL_ERR_NO_KEEPERS = -7,                // No ChronoKeepers available
+    CL_ERR_NO_CONNECTION = -8,             // No connection to ChronoVisor
+    CL_ERR_NOT_AUTHORIZED = -9,            // Unauthorized operation
+    CL_ERR_NO_PLAYERS = -10,               // No ChronoPlayers available
+    CL_ERR_NOT_READER_MODE = -11,          // Client is running in WRITER_MODE
+    CL_ERR_QUERY_TIMED_OUT = -12,          // Replay query timed out
+    CL_ERR_PROTOCOL_VERSION_MISMATCH = -13 // Client and server disagree on the wire-protocol version
 };
 
 // Convert enum value to its name (for logging)
@@ -53,6 +54,8 @@ inline const char* to_string(ClientErrorCode e)
             return "CL_ERR_NOT_READER_MODE";
         case CL_ERR_QUERY_TIMED_OUT:
             return "CL_ERR_QUERY_TIMED_OUT";
+        case CL_ERR_PROTOCOL_VERSION_MISMATCH:
+            return "CL_ERR_PROTOCOL_VERSION_MISMATCH";
         default:
             return "UnknownClientErrorCode";
     }
@@ -75,6 +78,7 @@ inline const char* to_string_client(int code)
         case CL_ERR_NO_PLAYERS:
         case CL_ERR_NOT_READER_MODE:
         case CL_ERR_QUERY_TIMED_OUT:
+        case CL_ERR_PROTOCOL_VERSION_MISMATCH:
             return to_string(static_cast<chronolog::ClientErrorCode>(code));
         default:
             return "UnknownClientErrorCode";

--- a/Client/cpp/src/rpcVisorClient.h
+++ b/Client/cpp/src/rpcVisorClient.h
@@ -17,6 +17,7 @@
 #include <thallium/serialization/stl/map.hpp>
 
 #include <chrono_monitor.h>
+#include <chronolog_client.h>
 #include <chronolog_types.h>
 #include <ConnectResponseMsg.h>
 #include <AcquireStoryResponseMsg.h>
@@ -49,13 +50,15 @@ public:
 
     ConnectResponseMsg Connect(uint32_t client_euid, uint32_t client_host_ip, uint32_t client_pid)
     {
-        LOG_DEBUG("[RpcVisorClient] Initiating connection for Account={}, HostID={}, PID={}",
+        LOG_DEBUG("[RpcVisorClient] Initiating connection for Account={}, HostID={}, PID={}, ProtocolVersion={}",
                   client_euid,
                   client_host_ip,
-                  client_pid);
+                  client_pid,
+                  chronolog::CLIENT_PROTOCOL_VERSION);
         try
         {
-            ConnectResponseMsg response = visor_connect.on(service_ph)(client_euid, client_host_ip, client_pid);
+            ConnectResponseMsg response = visor_connect.on(
+                    service_ph)(client_euid, client_host_ip, client_pid, chronolog::CLIENT_PROTOCOL_VERSION);
             LOG_INFO("[RpcVisorClient] Connection successful for Account={}, HostID={}, PID={}",
                      client_euid,
                      client_host_ip,


### PR DESCRIPTION
Adds a `protocol_version` field to the Connect handshake so client/server wire incompatibilities surface as a clear error code instead of letting Cereal silently deserialize garbage when struct shapes diverge underneath. The client passes `chronolog::CLIENT_PROTOCOL_VERSION` (currently 1) as a fourth positional argument on Connect; the Visor checks it against its own expected version and responds with the new `CL_ERR_PROTOCOL_VERSION_MISMATCH` error code on mismatch. The version constant lives in `chronolog_client.h` alongside the rest of the public client surface, and the bump policy is documented next to it: increment whenever a future wire change makes older clients incompatible with the server.

This is a breaking wire change between the client and the Visor, so both have to land together. Relevant once the client SDK starts being deployed against external servers and version skew becomes a real failure mode rather than a hypothetical one.

Stacked on top of #620 (the type-relocation work). Targets `develop` so CI runs; will rebase if #620 lands first.

Closes #618.

---
Linked issues (added retroactively):
Closes #613
