### PR TITLE
Add CI guard against chrono_common symbol leakage in client library

### DIFF
--- a/Client/cpp/CMakeLists.txt
+++ b/Client/cpp/CMakeLists.txt
@@ -87,6 +87,20 @@ set_target_properties(chronolog_client PROPERTIES
 )
 
 #------------------------------------------------------------------------------
+# Symbol-leakage guard
+#------------------------------------------------------------------------------
+# After issue #616, chronolog_client must not link any chrono_common compiled
+# code. This POST_BUILD check asserts the invariant by scanning the built
+# shared library for known chrono_common-only symbols and failing the build
+# if any leak in. See Client/cpp/check_no_chrono_common_symbols.sh.
+add_custom_command(TARGET chronolog_client POST_BUILD
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/check_no_chrono_common_symbols.sh
+            $<TARGET_FILE:chronolog_client>
+    COMMENT "Checking chronolog_client for chrono_common symbol leakage"
+    VERBATIM
+)
+
+#------------------------------------------------------------------------------
 # Install library, headers, and configuration file
 #------------------------------------------------------------------------------
 # Install chronolog_client with export (chrono_common is not installed as it's

--- a/Client/cpp/check_no_chrono_common_symbols.sh
+++ b/Client/cpp/check_no_chrono_common_symbols.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# CI guard for the client decoupling work (issue #619).
+#
+# After the client library was unlinked from chrono_common (#616 / PR #620),
+# libchronolog_client.so should contain zero symbols defined by chrono_common's
+# compiled translation units. This script asserts that invariant by grepping
+# the demangled symbol table of the built shared library for known
+# chrono_common-only class/function names. If any are present, the build fails
+# with a descriptive message.
+#
+# Usage: check_no_chrono_common_symbols.sh /path/to/libchronolog_client.so
+
+set -euo pipefail
+
+LIB_PATH="${1:?usage: $0 /path/to/libchronolog_client.so}"
+
+if [[ ! -f "$LIB_PATH" ]]; then
+    echo "[check_no_chrono_common_symbols] Library not found: $LIB_PATH" >&2
+    exit 2
+fi
+
+if ! command -v nm >/dev/null 2>&1; then
+    echo "[check_no_chrono_common_symbols] nm not available; skipping symbol-leakage check" >&2
+    exit 0
+fi
+
+# Patterns derived from chrono_common's compiled .cpp units:
+#   StoryChunk.cpp, StoryChunkExtractor.cpp, StoryChunkWriter.cpp,
+#   StoryPipeline.cpp, ChunkExtractorCSV.cpp, ChunkExtractorRDMA.cpp,
+#   RDMATransferAgent.cpp, city.cpp.
+# These are the class and function names that should never appear as defined
+# symbols in libchronolog_client.so.
+FORBIDDEN_PATTERNS=(
+    'StoryChunk::'
+    'StoryChunkExtractor'
+    'StoryChunkWriter'
+    'StoryPipeline'
+    'ChunkExtractorCSV'
+    'ChunkExtractorRDMA'
+    'chronolog::RDMATransferAgent'
+    'CityHash'
+)
+
+# nm -C demangles; --defined-only filters out undefined references; we only
+# care about symbols actually shipped in this library.
+SYMBOL_DUMP=$(nm -C --defined-only "$LIB_PATH" 2>/dev/null || true)
+
+LEAKED=()
+for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+    if matches=$(echo "$SYMBOL_DUMP" | grep -F -- "$pattern" || true); [[ -n "$matches" ]]; then
+        LEAKED+=("--- pattern: $pattern ---")
+        LEAKED+=("$matches")
+    fi
+done
+
+if (( ${#LEAKED[@]} > 0 )); then
+    {
+        echo "[check_no_chrono_common_symbols] FAIL: chrono_common-origin symbols leaked into $LIB_PATH"
+        echo
+        printf '%s\n' "${LEAKED[@]}"
+        echo
+        echo "The client library is supposed to be self-contained — it must not link any"
+        echo "chrono_common compiled object code. If a new symbol leaked in, either:"
+        echo "  - the offending header should be moved to Client/cpp/include/, or"
+        echo "  - the dependency should be eliminated rather than re-introduced."
+    } >&2
+    exit 1
+fi
+
+echo "[check_no_chrono_common_symbols] OK: $(basename "$LIB_PATH") contains no chrono_common-origin symbols"


### PR DESCRIPTION
Defense-in-depth follow-up to the client decoupling work. After #616 unlinked `chrono_common` from `chronolog_client`, `libchronolog_client.so` is supposed to be self-contained — no chrono_common compiled code in it. This adds a small `POST_BUILD` script (`Client/cpp/check_no_chrono_common_symbols.sh`) that runs `nm -C --defined-only` against the just-built shared library and fails the build with a descriptive error if any chrono_common-origin class or function name (`StoryChunk::*`, `RDMATransferAgent`, `StoryPipeline`, `ChunkExtractor*`, `CityHash`, etc.) shows up as a defined symbol in it.

The check runs identically locally and in CI, so no workflow YAML changes are needed and failures surface at build time rather than buried in test output. If a future change accidentally re-introduces a chrono_common dependency, the build now fails fast with a clear message pointing at the offending symbol.

Stacked on top of #620 (the type-relocation work). Targets `develop` so CI runs; will rebase if #620 lands first.

Closes #619.