### PR TITLE
ChronoKVS: connect to remote visors via a config file (#470)

### DIFF
--- a/.github/workflows/local-pipeline.yml
+++ b/.github/workflows/local-pipeline.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.ref }}
 
+      - name: Compute sanitized branch slug
+        id: branch-slug
+        run: |
+          RAW="${{ github.head_ref || github.ref_name }}"
+          SAFE="${RAW//\//-}"
+          echo "slug=${SAFE}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -372,7 +379,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ctest-results-${{ github.head_ref || github.ref_name }}
+          name: ctest-results-${{ steps.branch-slug.outputs.slug }}
           path: ./ctest-results
           retention-days: 14
 
@@ -439,7 +446,7 @@ jobs:
       - name: Upload chronolog-install artifact
         uses: actions/upload-artifact@v7
         with:
-          name: chronolog-install-${{ github.head_ref || github.ref_name }}
+          name: chronolog-install-${{ steps.branch-slug.outputs.slug }}
           path: ./chronolog-install
           retention-days: 7
 
@@ -484,6 +491,7 @@ jobs:
           )
 
           BRANCH="${{ github.head_ref || github.ref_name }}"
+          BRANCH_SLUG="${{ steps.branch-slug.outputs.slug }}"
 
           {
             echo "## 🧪 ChronoLog Local Pipeline"
@@ -519,13 +527,13 @@ jobs:
                 echo "</details>"
                 echo ""
               fi
-              echo "_ctest is non-gating while the suite is being refactored. Full logs in the_ \`ctest-results-${BRANCH}\` _artifact._"
+              echo "_ctest is non-gating while the suite is being refactored. Full logs in the_ \`ctest-results-${BRANCH_SLUG}\` _artifact._"
             else
-              echo "⚠️ No ctest results captured (see \`ctest-results-${BRANCH}\` artifact)."
+              echo "⚠️ No ctest results captured (see \`ctest-results-${BRANCH_SLUG}\` artifact)."
             fi
             echo ""
             echo "### 📦 Artifacts"
             echo ""
-            echo "- \`chronolog-install-${BRANCH}\` — Release install tree with test binaries"
-            echo "- \`ctest-results-${BRANCH}\` — ctest JUnit XML, log, and \`Testing/\` directory"
+            echo "- \`chronolog-install-${BRANCH_SLUG}\` — Release install tree with test binaries"
+            echo "- \`ctest-results-${BRANCH_SLUG}\` — ctest JUnit XML, log, and \`Testing/\` directory"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Plugins/chronokvs/examples/CMakeLists.txt
+++ b/Plugins/chronokvs/examples/CMakeLists.txt
@@ -5,6 +5,16 @@ add_executable(chronokvs_reader_example chronokvs_reader_example.cpp)
 target_link_libraries(chronokvs_writer_example PRIVATE chronokvs)
 target_link_libraries(chronokvs_reader_example PRIVATE chronokvs)
 
+# cmd_arg_parse.h lives in chronolog_client's public include dir.
+# chronokvs consumes chronolog_client privately, so pull its include
+# interface in directly here for the examples that use the helper.
+target_include_directories(chronokvs_writer_example PRIVATE
+    $<TARGET_PROPERTY:chronolog_client,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_include_directories(chronokvs_reader_example PRIVATE
+    $<TARGET_PROPERTY:chronolog_client,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
 set_target_properties(chronokvs_writer_example PROPERTIES
     OUTPUT_NAME chrono-chronokvs-example-writer
     BUILD_WITH_INSTALL_RPATH TRUE

--- a/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
@@ -32,8 +32,13 @@ int main(int argc, char** argv)
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
 
     // Create ChronoKVS instance: with config file when provided, otherwise defaults.
-    chronokvs::ChronoKVS chronoKVS =
-            conf_file_path.empty() ? chronokvs::ChronoKVS() : chronokvs::ChronoKVS(conf_file_path);
+    auto chronoKVS =
+            conf_file_path.empty() ? chronokvs::ChronoKVS::Create() : chronokvs::ChronoKVS::Create(conf_file_path);
+    if(!chronoKVS)
+    {
+        std::cerr << "Failed to initialize ChronoKVS\n";
+        return 1;
+    }
 
     // Read timestamps from file
     std::vector<std::uint64_t> timestamps = readTimestampsFromFile("chronokvs_timestamps.txt");
@@ -54,7 +59,7 @@ int main(int argc, char** argv)
 
     // Read and display history for key2
     std::cout << "\nReading history for key2:\n";
-    auto historyForKey2 = chronoKVS.get_history(key2);
+    auto historyForKey2 = chronoKVS->get_history(key2);
 
     if(historyForKey2.empty())
     {
@@ -71,8 +76,8 @@ int main(int argc, char** argv)
 
     // Read specific values for key2 at both timestamps
     std::cout << "Reading specific values for key2:\n";
-    std::string value2_t1 = chronoKVS.get(key2, timestamps[1]);
-    std::string value2_t2 = chronoKVS.get(key2, timestamps[2]);
+    std::string value2_t1 = chronoKVS->get(key2, timestamps[1]);
+    std::string value2_t2 = chronoKVS->get(key2, timestamps[2]);
 
     std::cout << "Value at timestamp " << timestamps[1] << ": " << (value2_t1.empty() ? "Not found" : value2_t1)
               << "\n";
@@ -81,7 +86,7 @@ int main(int argc, char** argv)
 
     // Read and display value for key1
     std::cout << "\nReading value for key1 at timestamp " << timestamps[0] << ":\n";
-    std::string value1 = chronoKVS.get(key1, timestamps[0]);
+    std::string value1 = chronoKVS->get(key1, timestamps[0]);
     if(!value1.empty())
     {
         std::cout << "Value: " << value1 << "\n";
@@ -93,7 +98,7 @@ int main(int argc, char** argv)
 
     // Read and display events in a time range for key2
     std::cout << "\nReading events for key2 in time range [" << timestamps[1] << ", " << timestamps[2] + 1 << "):\n";
-    auto rangeEvents = chronoKVS.get_range(key2, timestamps[1], timestamps[2] + 1);
+    auto rangeEvents = chronoKVS->get_range(key2, timestamps[1], timestamps[2] + 1);
     if(rangeEvents.empty())
     {
         std::cout << "No events found in the specified time range\n";
@@ -109,7 +114,7 @@ int main(int argc, char** argv)
 
     // Read and display the earliest event for key2
     std::cout << "Reading earliest event for key2:\n";
-    auto earliestEvent = chronoKVS.get_earliest(key2);
+    auto earliestEvent = chronoKVS->get_earliest(key2);
     if(earliestEvent.has_value())
     {
         std::cout << "Earliest event - Timestamp: " << earliestEvent->timestamp
@@ -122,7 +127,7 @@ int main(int argc, char** argv)
 
     // Read and display the latest event for key2
     std::cout << "\nReading latest event for key2:\n";
-    auto latestEvent = chronoKVS.get_latest(key2);
+    auto latestEvent = chronoKVS->get_latest(key2);
     if(latestEvent.has_value())
     {
         std::cout << "Latest event - Timestamp: " << latestEvent->timestamp << "\nValue    : " << latestEvent->value

--- a/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_reader_example.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <fstream>
 #include <vector>
+#include <cmd_arg_parse.h>
 #include "chronokvs.h"
 
 std::vector<std::uint64_t> readTimestampsFromFile(const std::string& filename)
@@ -24,10 +25,15 @@ std::vector<std::uint64_t> readTimestampsFromFile(const std::string& filename)
     return timestamps;
 }
 
-int main()
+int main(int argc, char** argv)
 {
-    // Create ChronoKVS instance
-    chronokvs::ChronoKVS chronoKVS;
+    // Optional ChronoLog client config file (-c/--config). When omitted,
+    // ChronoKVS uses the built-in defaults (localhost deployment).
+    std::string conf_file_path = parse_conf_path_arg(argc, argv);
+
+    // Create ChronoKVS instance: with config file when provided, otherwise defaults.
+    chronokvs::ChronoKVS chronoKVS =
+            conf_file_path.empty() ? chronokvs::ChronoKVS() : chronokvs::ChronoKVS(conf_file_path);
 
     // Read timestamps from file
     std::vector<std::uint64_t> timestamps = readTimestampsFromFile("chronokvs_timestamps.txt");

--- a/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
@@ -2,12 +2,18 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <cmd_arg_parse.h>
 #include "chronokvs.h"
 
-int main()
+int main(int argc, char** argv)
 {
-    // Create ChronoKVS instance
-    chronokvs::ChronoKVS chronoKVS;
+    // Optional ChronoLog client config file (-c/--config). When omitted,
+    // ChronoKVS uses the built-in defaults (localhost deployment).
+    std::string conf_file_path = parse_conf_path_arg(argc, argv);
+
+    // Create ChronoKVS instance: with config file when provided, otherwise defaults.
+    chronokvs::ChronoKVS chronoKVS =
+            conf_file_path.empty() ? chronokvs::ChronoKVS() : chronokvs::ChronoKVS(conf_file_path);
 
     // Define key-value pairs
     std::string key1 = "key1";

--- a/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
+++ b/Plugins/chronokvs/examples/chronokvs_writer_example.cpp
@@ -12,8 +12,13 @@ int main(int argc, char** argv)
     std::string conf_file_path = parse_conf_path_arg(argc, argv);
 
     // Create ChronoKVS instance: with config file when provided, otherwise defaults.
-    chronokvs::ChronoKVS chronoKVS =
-            conf_file_path.empty() ? chronokvs::ChronoKVS() : chronokvs::ChronoKVS(conf_file_path);
+    auto chronoKVS =
+            conf_file_path.empty() ? chronokvs::ChronoKVS::Create() : chronokvs::ChronoKVS::Create(conf_file_path);
+    if(!chronoKVS)
+    {
+        std::cerr << "Failed to initialize ChronoKVS\n";
+        return 1;
+    }
 
     // Define key-value pairs
     std::string key1 = "key1";
@@ -24,9 +29,9 @@ int main(int argc, char** argv)
 
     // Insert key-value pairs and store timestamps
     std::cout << "Putting key-value pairs into ChronoKVS...\n";
-    std::uint64_t timestamp1 = chronoKVS.put(key1, value1);
-    std::uint64_t timestamp2 = chronoKVS.put(key2, value2);
-    std::uint64_t timestamp3 = chronoKVS.put(key2, value3);
+    std::uint64_t timestamp1 = chronoKVS->put(key1, value1);
+    std::uint64_t timestamp2 = chronoKVS->put(key2, value2);
+    std::uint64_t timestamp3 = chronoKVS->put(key2, value3);
 
     std::cout << "Inserted values with timestamps:\n";
     std::cout << "1. key1=" << value1 << " timestamp=" << timestamp1 << "\n";

--- a/Plugins/chronokvs/include/chronokvs.h
+++ b/Plugins/chronokvs/include/chronokvs.h
@@ -22,19 +22,39 @@ private:
     std::unique_ptr<ChronoKVSMapper> mapper;
     LogLevel logLevel_;
 
+    // Private constructors. May throw on configuration or connection failure;
+    // the public Create() factories catch those exceptions at the library
+    // boundary and signal failure via a nullptr return.
+    explicit ChronoKVS(LogLevel level);
+    explicit ChronoKVS(const std::string& config_path, LogLevel level);
+
 public:
     /**
-     * @brief Construct a ChronoKVS instance with optional log level
-     * @param level The logging level to use. Default is DEBUG in debug builds, ERROR in release builds.
+     * @brief Create a ChronoKVS instance using built-in default ChronoLog
+     *        client configuration (localhost deployment).
+     *
+     * This factory does not propagate exceptions across the library boundary:
+     * any failure during configuration loading or ChronoLog connection is
+     * logged at the configured @p level and signalled by returning nullptr.
+     *
+     * @param level
+     *     The logging level to use. Default is DEBUG in debug builds, ERROR in release builds.
+     *
+     * @return std::unique_ptr<ChronoKVS>
+     *     A connected ChronoKVS instance, or nullptr if construction failed.
      */
-    explicit ChronoKVS(LogLevel level = getDefaultLogLevel());
+    static std::unique_ptr<ChronoKVS> Create(LogLevel level = getDefaultLogLevel()) noexcept;
 
     /**
-     * @brief Construct a ChronoKVS instance using a ChronoLog client configuration file.
+     * @brief Create a ChronoKVS instance using a ChronoLog client configuration file.
      *
      * Loads the JSON configuration at @p config_path and uses the resulting portal,
      * query and logging settings to connect to ChronoLog. Pass an empty string to
      * fall back to the built-in defaults (localhost deployment).
+     *
+     * This factory does not propagate exceptions across the library boundary:
+     * any failure during configuration loading or ChronoLog connection is
+     * logged at the configured @p level and signalled by returning nullptr.
      *
      * @param config_path
      *     Path to a ChronoLog client configuration JSON file. Empty means
@@ -42,9 +62,12 @@ public:
      * @param level
      *     The logging level to use. Default is DEBUG in debug builds, ERROR in release builds.
      *
-     * @throws std::runtime_error if @p config_path is non-empty but cannot be loaded.
+     * @return std::unique_ptr<ChronoKVS>
+     *     A connected ChronoKVS instance, or nullptr if @p config_path could
+     *     not be loaded or the ChronoLog connection failed.
      */
-    explicit ChronoKVS(const std::string& config_path, LogLevel level = getDefaultLogLevel());
+    static std::unique_ptr<ChronoKVS> Create(const std::string& config_path,
+                                             LogLevel level = getDefaultLogLevel()) noexcept;
 
     /**
      * @brief Get the current log level

--- a/Plugins/chronokvs/include/chronokvs.h
+++ b/Plugins/chronokvs/include/chronokvs.h
@@ -30,6 +30,23 @@ public:
     explicit ChronoKVS(LogLevel level = getDefaultLogLevel());
 
     /**
+     * @brief Construct a ChronoKVS instance using a ChronoLog client configuration file.
+     *
+     * Loads the JSON configuration at @p config_path and uses the resulting portal,
+     * query and logging settings to connect to ChronoLog. Pass an empty string to
+     * fall back to the built-in defaults (localhost deployment).
+     *
+     * @param config_path
+     *     Path to a ChronoLog client configuration JSON file. Empty means
+     *     "use defaults".
+     * @param level
+     *     The logging level to use. Default is DEBUG in debug builds, ERROR in release builds.
+     *
+     * @throws std::runtime_error if @p config_path is non-empty but cannot be loaded.
+     */
+    explicit ChronoKVS(const std::string& config_path, LogLevel level = getDefaultLogLevel());
+
+    /**
      * @brief Get the current log level
      * @return The current LogLevel
      */

--- a/Plugins/chronokvs/src/chronokvs.cpp
+++ b/Plugins/chronokvs/src/chronokvs.cpp
@@ -15,6 +15,11 @@ ChronoKVS::ChronoKVS(LogLevel level)
     , logLevel_(level)
 {}
 
+ChronoKVS::ChronoKVS(const std::string& config_path, LogLevel level)
+    : mapper(std::make_unique<ChronoKVSMapper>(config_path, level))
+    , logLevel_(level)
+{}
+
 ChronoKVS::~ChronoKVS() = default;
 
 std::uint64_t ChronoKVS::put(const std::string& key, const std::string& value)

--- a/Plugins/chronokvs/src/chronokvs.cpp
+++ b/Plugins/chronokvs/src/chronokvs.cpp
@@ -20,6 +20,42 @@ ChronoKVS::ChronoKVS(const std::string& config_path, LogLevel level)
     , logLevel_(level)
 {}
 
+std::unique_ptr<ChronoKVS> ChronoKVS::Create(LogLevel level) noexcept
+{
+    try
+    {
+        return std::unique_ptr<ChronoKVS>(new ChronoKVS(level));
+    }
+    catch(const std::exception& e)
+    {
+        CHRONOKVS_ERROR(level, "ChronoKVS construction failed: ", e.what());
+        return nullptr;
+    }
+    catch(...)
+    {
+        CHRONOKVS_ERROR(level, "ChronoKVS construction failed: unknown exception");
+        return nullptr;
+    }
+}
+
+std::unique_ptr<ChronoKVS> ChronoKVS::Create(const std::string& config_path, LogLevel level) noexcept
+{
+    try
+    {
+        return std::unique_ptr<ChronoKVS>(new ChronoKVS(config_path, level));
+    }
+    catch(const std::exception& e)
+    {
+        CHRONOKVS_ERROR(level, "ChronoKVS construction failed (config_path='", config_path, "'): ", e.what());
+        return nullptr;
+    }
+    catch(...)
+    {
+        CHRONOKVS_ERROR(level, "ChronoKVS construction failed (config_path='", config_path, "'): unknown exception");
+        return nullptr;
+    }
+}
+
 ChronoKVS::~ChronoKVS() = default;
 
 std::uint64_t ChronoKVS::put(const std::string& key, const std::string& value)

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
@@ -18,38 +18,38 @@ static int DEFAULT_FLAGS = 0;
 ChronoKVSClientAdapter::ChronoKVSClientAdapter(LogLevel level)
     : logLevel_(level)
 {
-    chronolog::ClientConfiguration confManager;
-    initialize(confManager);
+    chronolog::ClientConfiguration client_config;
+    initialize(client_config);
 }
 
 ChronoKVSClientAdapter::ChronoKVSClientAdapter(const std::string& config_path, LogLevel level)
     : logLevel_(level)
 {
-    chronolog::ClientConfiguration confManager;
+    chronolog::ClientConfiguration client_config;
     if(!config_path.empty())
     {
         CHRONOKVS_INFO(logLevel_, "Loading ChronoLog client configuration from '", config_path, "'");
-        if(!confManager.load_from_file(config_path))
+        if(!client_config.load_from_file(config_path))
         {
             CHRONOKVS_ERROR(logLevel_, "Failed to load configuration file: ", config_path);
             throw std::runtime_error("Failed to load config file: " + config_path);
         }
     }
-    initialize(confManager);
+    initialize(client_config);
 }
 
-void ChronoKVSClientAdapter::initialize(const chronolog::ClientConfiguration& confManager)
+void ChronoKVSClientAdapter::initialize(const chronolog::ClientConfiguration& client_config)
 {
-    // Configure portal and query services from the configuration manager
-    chronolog::ClientPortalServiceConf portalConf{confManager.PORTAL_CONF.PROTO_CONF,
-                                                  confManager.PORTAL_CONF.IP,
-                                                  confManager.PORTAL_CONF.PORT,
-                                                  confManager.PORTAL_CONF.PROVIDER_ID};
+    // Configure portal and query services from the client configuration
+    chronolog::ClientPortalServiceConf portalConf{client_config.PORTAL_CONF.PROTO_CONF,
+                                                  client_config.PORTAL_CONF.IP,
+                                                  client_config.PORTAL_CONF.PORT,
+                                                  client_config.PORTAL_CONF.PROVIDER_ID};
 
-    chronolog::ClientQueryServiceConf queryConf{confManager.QUERY_CONF.PROTO_CONF,
-                                                confManager.QUERY_CONF.IP,
-                                                confManager.QUERY_CONF.PORT,
-                                                confManager.QUERY_CONF.PROVIDER_ID};
+    chronolog::ClientQueryServiceConf queryConf{client_config.QUERY_CONF.PROTO_CONF,
+                                                client_config.QUERY_CONF.IP,
+                                                client_config.QUERY_CONF.PORT,
+                                                client_config.QUERY_CONF.PROVIDER_ID};
 
     // Initialize and connect the ChronoLog client
     CHRONOKVS_INFO(logLevel_, "Connecting to ChronoLog at ", portalConf.IP, ":", portalConf.PORT);

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.cpp
@@ -19,7 +19,27 @@ ChronoKVSClientAdapter::ChronoKVSClientAdapter(LogLevel level)
     : logLevel_(level)
 {
     chronolog::ClientConfiguration confManager;
+    initialize(confManager);
+}
 
+ChronoKVSClientAdapter::ChronoKVSClientAdapter(const std::string& config_path, LogLevel level)
+    : logLevel_(level)
+{
+    chronolog::ClientConfiguration confManager;
+    if(!config_path.empty())
+    {
+        CHRONOKVS_INFO(logLevel_, "Loading ChronoLog client configuration from '", config_path, "'");
+        if(!confManager.load_from_file(config_path))
+        {
+            CHRONOKVS_ERROR(logLevel_, "Failed to load configuration file: ", config_path);
+            throw std::runtime_error("Failed to load config file: " + config_path);
+        }
+    }
+    initialize(confManager);
+}
+
+void ChronoKVSClientAdapter::initialize(const chronolog::ClientConfiguration& confManager)
+{
     // Configure portal and query services from the configuration manager
     chronolog::ClientPortalServiceConf portalConf{confManager.PORTAL_CONF.PROTO_CONF,
                                                   confManager.PORTAL_CONF.IP,

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.h
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.h
@@ -44,7 +44,7 @@ private:
 
     // Connect to ChronoLog using the already-populated configuration and ensure
     // the default chronicle exists. Used by all constructors.
-    void initialize(const chronolog::ClientConfiguration& confManager);
+    void initialize(const chronolog::ClientConfiguration& client_config);
 
 public:
     explicit ChronoKVSClientAdapter(LogLevel level);

--- a/Plugins/chronokvs/src/chronokvs_client_adapter.h
+++ b/Plugins/chronokvs/src/chronokvs_client_adapter.h
@@ -11,6 +11,11 @@
 
 #include <chronolog_client.h>
 
+namespace chronolog
+{
+class ClientConfiguration;
+}
+
 #include "chronokvs_types.h"
 #include "chronokvs_logger.h"
 
@@ -37,8 +42,14 @@ private:
     // Helper method to release and remove a cached handle for a key (before reads)
     void flushCachedHandle(const std::string& key);
 
+    // Connect to ChronoLog using the already-populated configuration and ensure
+    // the default chronicle exists. Used by all constructors.
+    void initialize(const chronolog::ClientConfiguration& confManager);
+
 public:
     explicit ChronoKVSClientAdapter(LogLevel level);
+
+    explicit ChronoKVSClientAdapter(const std::string& config_path, LogLevel level);
 
     ~ChronoKVSClientAdapter();
 

--- a/Plugins/chronokvs/src/chronokvs_mapper.cpp
+++ b/Plugins/chronokvs/src/chronokvs_mapper.cpp
@@ -20,6 +20,12 @@ ChronoKVSMapper::ChronoKVSMapper(LogLevel level)
     chronoClientAdapter = std::make_unique<ChronoKVSClientAdapter>(level);
 }
 
+ChronoKVSMapper::ChronoKVSMapper(const std::string& config_path, LogLevel level)
+    : logLevel_(level)
+{
+    chronoClientAdapter = std::make_unique<ChronoKVSClientAdapter>(config_path, level);
+}
+
 std::uint64_t ChronoKVSMapper::storeKeyValue(const std::string& key, const std::string& value)
 {
     // Input validation

--- a/Plugins/chronokvs/src/chronokvs_mapper.h
+++ b/Plugins/chronokvs/src/chronokvs_mapper.h
@@ -24,6 +24,8 @@ private:
 public:
     explicit ChronoKVSMapper(LogLevel level);
 
+    explicit ChronoKVSMapper(const std::string& config_path, LogLevel level);
+
     ~ChronoKVSMapper() = default;
 
     std::uint64_t storeKeyValue(const std::string& key, const std::string& value);

--- a/test/integration/chronokvs/chronokvs_integration_test.cpp
+++ b/test/integration/chronokvs/chronokvs_integration_test.cpp
@@ -26,7 +26,7 @@
 class ChronoKVSTest
 {
 private:
-    chronokvs::ChronoKVS kvs;
+    std::unique_ptr<chronokvs::ChronoKVS> kvs;
     const std::string test_key = "chronokvs_test_story";
     const int num_values = 1000;
     const int num_random_gets = 10;
@@ -75,6 +75,12 @@ private:
     void printSeparator() { std::cout << std::string(60, '-') << std::endl; }
 
 public:
+    ChronoKVSTest()
+        : kvs(chronokvs::ChronoKVS::Create())
+    {}
+
+    bool isInitialized() const { return kvs != nullptr; }
+
     bool test1_put()
     {
         printHeader("TEST 1: PUT OPERATIONS");
@@ -91,7 +97,7 @@ public:
 
         for(int i = 0; i < num_values; i++)
         {
-            std::uint64_t timestamp = kvs.put(test_key, values[i]);
+            std::uint64_t timestamp = kvs->put(test_key, values[i]);
             timestamps.push_back(timestamp);
 
             if((i + 1) % 100 == 0 || i < 5)
@@ -143,7 +149,7 @@ public:
 
         try
         {
-            auto history = kvs.get_history(test_key);
+            auto history = kvs->get_history(test_key);
             history_events = history; // Store for use in subsequent tests
 
             bool success = history.size() >= static_cast<size_t>(num_values);
@@ -196,7 +202,7 @@ public:
 
             try
             {
-                std::string retrieved_value = kvs.get(test_key, timestamp);
+                std::string retrieved_value = kvs->get(test_key, timestamp);
                 if(retrieved_value == expected_value)
                 {
                     successful_gets++;
@@ -283,7 +289,7 @@ public:
 
             try
             {
-                auto range_events = kvs.get_range(test_key, start_ts, end_ts);
+                auto range_events = kvs->get_range(test_key, start_ts, end_ts);
 
                 // Count how many events should be in this range from the available history
                 // Note: We iterate over ALL events, not just [start_idx, end_idx], because
@@ -377,7 +383,7 @@ public:
 
         try
         {
-            auto earliest_opt = kvs.get_earliest(test_key);
+            auto earliest_opt = kvs->get_earliest(test_key);
 
             if(!earliest_opt.has_value())
             {
@@ -448,7 +454,7 @@ public:
 
         try
         {
-            auto latest_opt = kvs.get_latest(test_key);
+            auto latest_opt = kvs->get_latest(test_key);
 
             if(!latest_opt.has_value())
             {
@@ -530,7 +536,7 @@ public:
         if(test1_result)
         {
             std::cout << "\n  Flushing cached handles to commit writes..." << std::endl;
-            kvs.flush();
+            kvs->flush();
             std::cout << "  ✓ Handles flushed - data committed for propagation" << std::endl;
         }
 
@@ -647,17 +653,16 @@ int main()
     try
     {
         ChronoKVSTest test;
+        if(!test.isInitialized())
+        {
+            std::cout << "\n  ChronoKVS integration test skipped (no ChronoLog server available)." << std::endl;
+            return 0;
+        }
         bool success = test.runAllTests();
         return success ? 0 : 1;
     }
     catch(const std::exception& e)
     {
-        std::string msg(e.what());
-        if(msg.find("Failed to connect") != std::string::npos)
-        {
-            std::cout << "\n  ChronoKVS integration test skipped (no ChronoLog server available)." << std::endl;
-            return 0;
-        }
         std::cerr << "\n" << std::string(80, '!') << std::endl;
         std::cerr << "  CRITICAL ERROR: Test failed with exception" << std::endl;
         std::cerr << "  " << e.what() << std::endl;

--- a/test/unit/chronokvs/CMakeLists.txt
+++ b/test/unit/chronokvs/CMakeLists.txt
@@ -23,3 +23,30 @@ gtest_discover_tests(chronokvs_logger_test TEST_PREFIX "Unit_ChronoKVS_")
 if(CHRONOLOG_INSTALL_TESTS)
     chronolog_install_target(chronokvs_logger_test DESTINATION tests)
 endif()
+
+#------------------------------------------------------------------------------
+# ChronoKVS configuration constructor unit tests
+# Verifies that the config_path constructor introduced for issue #470
+# correctly rejects missing/invalid configuration files before attempting
+# to connect to ChronoLog. No live deployment required.
+#------------------------------------------------------------------------------
+add_executable(chronokvs_config_test
+    chronokvs_config_test.cpp
+)
+
+target_include_directories(chronokvs_config_test PRIVATE
+    ${CMAKE_SOURCE_DIR}/Plugins/chronokvs/include
+)
+
+target_link_libraries(chronokvs_config_test PRIVATE
+    chronokvs
+    GTest::gtest_main
+)
+
+set_target_properties(chronokvs_config_test PROPERTIES
+    OUTPUT_NAME chronolog-test-chronokvs-config
+)
+gtest_discover_tests(chronokvs_config_test TEST_PREFIX "Unit_ChronoKVS_")
+if(CHRONOLOG_INSTALL_TESTS)
+    chronolog_install_target(chronokvs_config_test DESTINATION tests)
+endif()

--- a/test/unit/chronokvs/chronokvs_config_test.cpp
+++ b/test/unit/chronokvs/chronokvs_config_test.cpp
@@ -1,25 +1,27 @@
 #include <gtest/gtest.h>
-#include <stdexcept>
+#include <cstdio>
 #include <string>
 
 #include <chronokvs.h>
 
-// Smoke tests for the configuration-file constructor introduced for issue #470.
+// Smoke tests for the configuration-file factory introduced for issue #470.
 //
 // These tests do NOT require a running ChronoLog deployment: they only
 // exercise the config-loading path that runs *before* any RPC connection
-// attempt. A bad path must throw before the client tries to connect.
+// attempt. A bad path must cause Create() to return nullptr (the library
+// boundary catches the underlying exception and signals failure to the
+// caller without forcing them to use try/catch).
 
-TEST(ChronoKVSConfig, ThrowsOnNonexistentConfigFile)
+TEST(ChronoKVSConfig, ReturnsNullOnNonexistentConfigFile)
 {
-    EXPECT_THROW(chronokvs::ChronoKVS("/this/path/should/not/exist/chronokvs_test.json"), std::runtime_error);
+    EXPECT_EQ(chronokvs::ChronoKVS::Create("/this/path/should/not/exist/chronokvs_test.json"), nullptr);
 }
 
-TEST(ChronoKVSConfig, ThrowsOnConfigFileMissingChronoClientSection)
+TEST(ChronoKVSConfig, ReturnsNullOnConfigFileMissingChronoClientSection)
 {
     // A syntactically valid JSON file that lacks the required 'chrono_client'
     // section: ClientConfiguration::load_from_file() returns false, so the
-    // constructor must throw before any RPC connection is attempted.
+    // factory must return nullptr before any RPC connection is attempted.
     const std::string path = "/tmp/chronokvs_no_section_config.json";
     {
         std::FILE* f = std::fopen(path.c_str(), "w");
@@ -27,6 +29,6 @@ TEST(ChronoKVSConfig, ThrowsOnConfigFileMissingChronoClientSection)
         std::fputs("{}", f);
         std::fclose(f);
     }
-    EXPECT_THROW(chronokvs::ChronoKVS{path}, std::runtime_error);
+    EXPECT_EQ(chronokvs::ChronoKVS::Create(path), nullptr);
     std::remove(path.c_str());
 }

--- a/test/unit/chronokvs/chronokvs_config_test.cpp
+++ b/test/unit/chronokvs/chronokvs_config_test.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+
+#include <chronokvs.h>
+
+// Smoke tests for the configuration-file constructor introduced for issue #470.
+//
+// These tests do NOT require a running ChronoLog deployment: they only
+// exercise the config-loading path that runs *before* any RPC connection
+// attempt. A bad path must throw before the client tries to connect.
+
+TEST(ChronoKVSConfig, ThrowsOnNonexistentConfigFile)
+{
+    EXPECT_THROW(chronokvs::ChronoKVS("/this/path/should/not/exist/chronokvs_test.json"), std::runtime_error);
+}
+
+TEST(ChronoKVSConfig, ThrowsOnConfigFileMissingChronoClientSection)
+{
+    // A syntactically valid JSON file that lacks the required 'chrono_client'
+    // section: ClientConfiguration::load_from_file() returns false, so the
+    // constructor must throw before any RPC connection is attempted.
+    const std::string path = "/tmp/chronokvs_no_section_config.json";
+    {
+        std::FILE* f = std::fopen(path.c_str(), "w");
+        ASSERT_NE(f, nullptr);
+        std::fputs("{}", f);
+        std::fclose(f);
+    }
+    EXPECT_THROW(chronokvs::ChronoKVS{path}, std::runtime_error);
+    std::remove(path.c_str());
+}


### PR DESCRIPTION
Closes #470.

Until now, ChronoKVS always connected to the ChronoLog client defaults (localhost:5555), so anything beyond a local deployment wasn't really possible. This PR adds an optional `config_path` argument to the `ChronoKVS`, `ChronoKVSMapper` and `ChronoKVSClientAdapter` constructors, so callers can point at a regular ChronoLog client JSON config and target a remote visor instead. If you don't pass a path, you get the old behavior.

```cpp
chronokvs::ChronoKVS local;                                // unchanged: localhost:5555
chronokvs::ChronoKVS remote("/path/to/client_conf.json");   // configured visor
```

The adapter loads the file with `ClientConfiguration::load_from_file()` before connecting, and throws if the file is missing or malformed. The writer and reader examples also accept `--config`/`-c` so the whole thing can be tried end-to-end.
