### PR TITLE
Bump version to 2.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT DEFINED CMAKE_MACOSX_RPATH)
     set(CMAKE_MACOSX_RPATH 0)
 endif()
 
-project(ChronoLog VERSION 2.7.0 LANGUAGES CXX C)
+project(ChronoLog VERSION 2.8.0 LANGUAGES CXX C)
 
 #------------------------------------------------------------------------------
 # Version information


### PR DESCRIPTION
Bumps the CMake project version from 2.7.0 to 2.8.0 ahead of the v2.8.0 release. `CMakeLists.txt` is the only place that needs to change — `cmake/version.h.in` picks the value up from `PROJECT_VERSION`, and the other `2.7.0` strings around the repo (the versioned docs snapshot, the CPack config example, the reports under `doc/`) aren't tied to the project version.

Closes #648